### PR TITLE
Allow the OEM to control what the ODM is able to do

### DIFF
--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -147,6 +147,9 @@ class User(db.Model):
     human_user_id = Column(Integer, ForeignKey('users.user_id'), nullable=True)
     notify_demote_failures = Column(Boolean, default=False)
     notify_server_error = Column(Boolean, default=False)
+    notify_upload_vendor = Column(Boolean, default=False)
+    notify_upload_affiliate = Column(Boolean, default=False)
+    notify_promote = Column(Boolean, default=False)
 
     # link using foreign keys
     vendor = relationship('Vendor', foreign_keys=[vendor_id])
@@ -1715,6 +1718,22 @@ class Firmware(db.Model):
         if self._banned_country_codes:
             return self._banned_country_codes
         return self.vendor.banned_country_codes
+
+    @property
+    def get_possible_users_to_email(self):
+        users = []
+
+        # vendor that owns the firmware
+        for u in self.vendor.users:
+            if u.is_qa or u.is_vendor_manager:
+                users.append(u)
+
+        # odm that uploaded the firmware
+        if self.vendor != self.vendor_odm:
+            for u in self.vendor_odm.users:
+                if u.is_qa or u.is_vendor_manager:
+                    users.append(u)
+        return users
 
     @property
     def success(self):

--- a/lvfs/templates/email-firmware-promote.txt
+++ b/lvfs/templates/email-firmware-promote.txt
@@ -1,0 +1,14 @@
+Dear {{ user.display_name }},
+
+A firmware you uploaded to the Linux Vendor Firmware Service has been promoted to {{fw.remote.name}} by {{user.username}} ({{user.vendor.group_id}}):
+{% for md in fw.mds %}
+ * {{md.name_with_category}} version {{md.version_display}}
+{% endfor %}
+
+You can log into the LVFS and view the firmware: {{url_for('.firmware_show', firmware_id=fw.firmware_id, _external=True)}}
+
+If you believe this action should not have been allowed please contact the LVFS administrator by forwarding the email to info@fwupd.org with details.
+
+Regards,
+
+The LVFS admins

--- a/lvfs/templates/email-firmware-uploaded.txt
+++ b/lvfs/templates/email-firmware-uploaded.txt
@@ -1,0 +1,15 @@
+Dear {{ user.display_name }},
+
+A firmware has been uploaded to the Linux Vendor Firmware Service by {{user_upload.username}} ({{user_upload.vendor.group_id}}):
+
+{% for md in fw.mds %}
+ * {{md.name_with_category}} version {{md.version_display}}
+{% endfor %}
+
+You can log into the LVFS and view the firmware: {{url_for('.firmware_show', firmware_id=fw.firmware_id, _external=True)}}
+
+If you believe this action should not have been allowed please contact the LVFS administrator by forwarding the email to info@fwupd.org with details.
+
+Regards,
+
+The LVFS admins

--- a/lvfs/templates/firmware-affiliation.html
+++ b/lvfs/templates/firmware-affiliation.html
@@ -25,7 +25,7 @@
         <label for="vendor_id">Controlling vendor</label>
         <select class="form-control" name="vendor_id" required>
 {% for v in vendors %}
-          <option value="{{v.vendor_id}}" {{ 'selected' if v.vendor_id == fw.vendor_id }}>{{v.display_name}}</option>
+          <option value="{{v.vendor_id}}" {{ 'selected' if v.vendor_id == fw.vendor_id }}>{{v.display_name_with_team}}</option>
 {% endfor %}
         </select>
       </div>

--- a/lvfs/templates/firmware-nav.html
+++ b/lvfs/templates/firmware-nav.html
@@ -21,7 +21,7 @@
       <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'firmware_problems' else 'default'}}"
         href="{{url_for('.firmware_problems', firmware_id=fw.firmware_id)}}">Problems</a>
 {% endif %}
-{% if not fw.do_not_track and (fw.check_acl('@add-limit') or fw.check_acl('@remove-limit')) %}
+{% if not fw.do_not_track and fw.check_acl('@modify-limit') %}
       <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'firmware_limits' else 'default'}}"
         href="{{url_for('.firmware_limits', firmware_id=fw.firmware_id)}}">Limits</a>
 {% endif %}

--- a/lvfs/templates/firmware-problems.html
+++ b/lvfs/templates/firmware-problems.html
@@ -132,6 +132,26 @@
         to the source code used to build the firmware.
       </p>
     </td>
+{% elif problem.kind == 'no-vendor-namespace' %}
+    <td class="col col-sm-7">
+      <p class="card-text">
+        The <code>{{problem.md.fw.vendor.group_id}}</code> vendor
+        does not have permission to own the <code>{{problem.md.appstream_id_prefix}}</code>
+        AppStream ID component prefix and no namespaces have been set up.
+        Please either change the firmware vendor or contact the LVFS
+        administrator to fix this.
+      </p>
+    </td>
+{% elif problem.kind == 'invalid-vendor-namespace' %}
+    <td class="col col-sm-7">
+      <p class="card-text">
+        The <code>{{problem.md.fw.vendor.group_id}}</code> vendor
+        does not have permission to own the <code>{{problem.md.appstream_id_prefix}}</code>
+        AppStream ID component prefix.
+        Please either <a href="{{url_for('.firmware_affiliation', firmware_id=problem.md.fw.firmware_id)}}">change the vendor</a>
+        to the correct OEM or contact the LVFS administrator to fix this.
+      </p>
+    </td>
 {% else %}
     <td class="col col-sm-7">
       <p class="card-text">

--- a/lvfs/templates/firmware-search.html
+++ b/lvfs/templates/firmware-search.html
@@ -30,7 +30,7 @@
   <tr class="row">
     <td class="col col-sm-8">
       <p class="list-group-item-title">
-        {{fw.md_prio.developer_name_display}}
+        {{fw.vendor.display_name}}
         {{fw.md_prio.name_with_category}}
       </p>
       <p class="text-muted">

--- a/lvfs/templates/profile.html
+++ b/lvfs/templates/profile.html
@@ -70,6 +70,42 @@
           </div>
         </div>
 {% endif %}
+{% if g.user.is_qa %}
+        <div class="row">
+          <div class="col">
+            <div class="custom-control custom-switch">
+              <input class="custom-control-input" type="checkbox" id="notify_upload_vendor"
+                name="notify_upload_vendor" value="1" {{'checked' if u.notify_upload_vendor}}/>
+              <label class="custom-control-label" for="notify_upload_vendor">
+                When firmware is uploaded by anyone in the {{u.vendor.group_id}} group.
+              </label>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col">
+            <div class="custom-control custom-switch">
+              <input class="custom-control-input" type="checkbox" id="notify_upload_affiliate"
+                name="notify_upload_affiliate" value="1" {{'checked' if u.notify_upload_affiliate}}/>
+              <label class="custom-control-label" for="notify_upload_affiliate">
+                When firmware is uploaded by an affiliate vendor on
+                behalf of the {{u.vendor.group_id}} group.
+              </label>
+            </div>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col">
+            <div class="custom-control custom-switch">
+              <input class="custom-control-input" type="checkbox" id="notify_promote"
+                name="notify_promote" value="1" {{'checked' if u.notify_promote}}/>
+              <label class="custom-control-label" for="notify_promote">
+                When firmware is promted to testing or stable.
+              </label>
+            </div>
+          </div>
+        </div>
+{% endif %}
         <button class="btn btn-primary mt-3" type="submit">Update</button>
       </div>
     </div>

--- a/lvfs/templates/vendor-affiliations.html
+++ b/lvfs/templates/vendor-affiliations.html
@@ -5,17 +5,26 @@
 
 {% block content %}
 {% if v.check_acl('@modify-affiliations') %}
+
+{% if v.namespaces %}
 <div class="alert alert-warning mt-1" role="alert">
   Be <b>very careful</b> using this feature as ODMs will be able to upload to
   OEM embargo targets, and OEMs will be able to delete ODM firmware.
 </div>
+{% else %}
+<div class="alert alert-warning mt-1" role="alert">
+  No AppStream <a href="{{url_for('.vendor_namespaces', vendor_id=v.vendor_id)}}">namespaces</a>
+  have been set up and therefore no new affiliates can be created.
+</div>
+{% endif %}
+
 {% else %}
 <div class="alert alert-info mt-1" role="alert">
   Please contact the LVFS administrator if you would like to add or remove affiliations.
 </div>
 {% endif %}
 
-{% if v.check_acl('@modify-affiliations') %}
+{% if v.namespaces and v.check_acl('@modify-affiliations') %}
 <form method="post" action="{{url_for('.vendor_affiliation_add', vendor_id=v.vendor_id)}}">
 <input type="hidden" name="csrf_token" value="{{csrf_token()}}"/>
 <div class="card mt-3">
@@ -25,7 +34,7 @@
       <select class="form-control" name="vendor_id_odm">
 {% for ov in other_vendors %}
         <option value="{{ov.vendor_id}}" required>
-          {{ov.display_name}}
+          {{ov.display_name_with_team}}
         </option>
 {% endfor %}
       </select>
@@ -39,32 +48,63 @@
 {% if v.affiliations|length == 0 %}
 <div class="card mt-3">
   <div class="card-body">
-    <div class="card-title">ODMs acting on behalf of {{v.display_name}}</div>
+    <div class="card-title">ODMs acting on behalf of {{v.display_name_with_team}}</div>
     <p class="card-text">
       No affiliations exist.
     </p>
   </div>
 </div>
 {% else %}
-<div class="card-columns mt-3">
-{% for r in v.affiliations %}
-  <div class="card">
-    <div class="card-body">
-      <div class="card-title">
-        {{r.vendor_odm.display_name}}
-{% if r.vendor_odm.icon %}
-        <img class="float-right" src="/uploads/{{r.vendor_odm.icon}}" width="64"/>
-{% endif %}
-      </div>
-{% if v.check_acl('@modify-affiliations') %}
-      <a class="card-link btn btn-danger"
-        href="{{url_for('.vendor_affiliation_delete', vendor_id=v.vendor_id, affiliation_id=r.affiliation_id)}}"
-        role="button">Remove</a>
+{% for aff in v.affiliations %}
+<div class="card mt-3">
+  <div class="card-body">
+    <div class="card-title">
+      {{aff.vendor_odm.display_name_with_team}}
+{% if aff.vendor_odm.icon %}
+      <img class="float-right mb-3" src="/uploads/{{aff.vendor_odm.icon}}" width="64"/>
 {% endif %}
     </div>
-  </div>
+    <table class="table mt-3">
+      <tr class="row">
+        <th class="col">Action</td>
+        <th class="col">Added on</td>
+        <th class="col">Added by</td>
+        <th class="col col-2">&nbsp;</th>
+      </tr>
+{% for possible_action in possible_actions %}
+{% set act = aff.get_action(possible_action) %}
+      <tr class="row">
+        <td class="col">{{possible_actions[possible_action]}}</td>
+        <td class="col">{{act.ctime if act else '—'}}</td>
+        <td class="col"><code>{{act.user.username if act else '—'}}</code></td>
+        <td class="col col-2">
+{% if v.check_acl('@modify-affiliation-actions') %}
+{% if act %}
+          <a class="btn btn-warning btn-block"
+            href="{{url_for('.vendor_affiliation_action_remove',
+                            vendor_id=aff.vendor_id,
+                            affiliation_id=aff.affiliation_id,
+                            action=act.action)}}">Remove</a>
+{% else %}
+          <a class="btn btn-primary btn-block"
+            href="{{url_for('.vendor_affiliation_action_add',
+                            vendor_id=aff.vendor_id,
+                            affiliation_id=aff.affiliation_id,
+                            action=possible_action)}}">Add</a>
+{% endif %}
+{% endif %}
+        </td>
+      </tr>
 {% endfor %}
+    </table>
+{% if v.check_acl('@modify-affiliation-actions') %}
+    <a class="card-link btn btn-danger"
+      href="{{url_for('.vendor_affiliation_delete', vendor_id=v.vendor_id, affiliation_id=aff.affiliation_id)}}"
+      role="button">Delete</a>
+{% endif %}
+  </div>
 </div>
+{% endfor %}
 {% endif %}
 
 {% endblock %}

--- a/lvfs/views_firmware.py
+++ b/lvfs/views_firmware.py
@@ -33,7 +33,8 @@ def firmware(state=None):
     # pre-filter by user ID or vendor
     if g.user.is_analyst or g.user.is_qa:
         stmt = db.session.query(Firmware).\
-                    filter(Firmware.vendor_id == g.user.vendor.vendor_id)
+                    filter((Firmware.vendor_id == g.user.vendor.vendor_id) | \
+                           (Firmware.user_id == g.user.user_id))
     else:
         stmt = db.session.query(Firmware).\
                     filter(Firmware.user_id == g.user.user_id)
@@ -361,7 +362,7 @@ def firmware_limit_add():
         return redirect(url_for('.firmware'))
 
     # security check
-    if not fw.check_acl('@add-limit'):
+    if not fw.check_acl('@modify-limit'):
         flash('Permission denied: Unable to add restriction', 'danger')
         return redirect(url_for('.firmware_show', firmware_id=fw.firmware_id))
 
@@ -438,7 +439,7 @@ def firmware_affiliation_change(firmware_id):
     if vendor_id == fw.vendor_id:
         flash('No affiliation change required', 'info')
         return redirect(url_for('.firmware_affiliation', firmware_id=fw.firmware_id))
-    if not g.user.is_admin and not g.user.vendor.is_affiliate_for(vendor_id):
+    if not g.user.is_admin and not g.user.vendor.is_affiliate_for(vendor_id) and vendor_id != g.user.vendor_id:
         flash('Insufficient permissions to change affiliation to {}'.format(vendor_id), 'danger')
         return redirect(url_for('.firmware_show', firmware_id=firmware_id))
     old_vendor = fw.vendor

--- a/lvfs/views_user.py
+++ b/lvfs/views_user.py
@@ -79,6 +79,8 @@ def user_modify(user_id):
 
     # unchecked checkbuttons are not included in the form data
     for key in ['notify_demote_failures',
+                'notify_upload_vendor',
+                'notify_upload_affiliate',
                 'notify_server_error']:
         setattr(user, key, bool(key in request.form))
 

--- a/migrations/versions/44250e0a730e_add_affiliate_action.py
+++ b/migrations/versions/44250e0a730e_add_affiliate_action.py
@@ -1,0 +1,46 @@
+"""
+
+Revision ID: 44250e0a730e
+Revises: 9373c9ac33da
+Create Date: 2019-09-09 11:30:12.578540
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '44250e0a730e'
+down_revision = '9373c9ac33da'
+
+from alembic import op
+import sqlalchemy as sa
+
+from lvfs import db
+from lvfs.models import Affiliation, AffiliationAction
+
+def upgrade():
+    op.create_table('affiliation_actions',
+    sa.Column('affiliation_action_id', sa.Integer(), nullable=False),
+    sa.Column('affiliation_id', sa.Integer(), nullable=False),
+    sa.Column('ctime', sa.DateTime(), nullable=False),
+    sa.Column('user_id', sa.Integer(), nullable=False),
+    sa.Column('action', sa.Text(), nullable=True),
+    sa.ForeignKeyConstraint(['affiliation_id'], ['affiliations.affiliation_id'], ),
+    sa.ForeignKeyConstraint(['user_id'], ['users.user_id'], ),
+    sa.PrimaryKeyConstraint('affiliation_action_id'),
+    sa.UniqueConstraint('affiliation_action_id'),
+    mysql_character_set='utf8mb4'
+    )
+
+    # migrate affiliates to a sane set
+    for aff in db.session.query(Affiliation):
+        if aff.actions:
+            continue
+        for action in ['@delete',
+                       '@modify',
+                       '@undelete',
+                       '@modify-updateinfo',
+                       '@view']:
+            aff.actions.append(AffiliationAction(action=action, user_id=1))
+    db.session.commit()
+
+def downgrade():
+    op.drop_table('affiliation_actions')

--- a/migrations/versions/7cd25be1d3ee_add_notify_for_oem.py
+++ b/migrations/versions/7cd25be1d3ee_add_notify_for_oem.py
@@ -1,0 +1,24 @@
+"""
+
+Revision ID: 7cd25be1d3ee
+Revises: 44250e0a730e
+Create Date: 2019-09-09 11:42:43.752086
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '7cd25be1d3ee'
+down_revision = '44250e0a730e'
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.add_column('users', sa.Column('notify_promote', sa.Boolean(), nullable=True))
+    op.add_column('users', sa.Column('notify_upload_affiliate', sa.Boolean(), nullable=True))
+    op.add_column('users', sa.Column('notify_upload_vendor', sa.Boolean(), nullable=True))
+
+def downgrade():
+    op.drop_column('users', 'notify_upload_vendor')
+    op.drop_column('users', 'notify_upload_affiliate')
+    op.drop_column('users', 'notify_promote')


### PR DESCRIPTION
To enforce this, we also need to add the concept of vendor namespaces.
The namespace prefix is the AppStream ID prefix that can be displayed to the
user. The OEM is the 'owner' of the ID prefix, and never the ODM. Add a
firmware 'problems' for existing firmware on the LVFS that hasn't already been
pushed to stable.

This prevents the ODM being 'credited' with the hardware when they are just
managing the entire end-to-end firmware lifecycle for the OEM as part of a
contract. Adding the actions to an ACL list allows us to better explain to the
vendor manager what the ODM is able to do, without hardcoding the logic.

Additionally, add an optional notfication email for ODM or OEM upload so that
the OEM is aware of what the ODM is doing.

Fixes https://github.com/fwupd/lvfs-website/issues/380