### PR TITLE
Check the source and release URLs are valid if provided

### DIFF
--- a/local.py
+++ b/local.py
@@ -9,12 +9,12 @@
 
 import os
 import sys
+import argparse
 
 from lvfs.metadata import _generate_metadata_kind
 from lvfs.uploadedfile import UploadedFile
 
 def parse_args():
-    import argparse
     parser = argparse.ArgumentParser(description="Generate local metadata to use with fwupd")
     parser.add_argument("--archive-directory", default=".",
                         help="Local directory of CAB archives to scan")

--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -95,6 +95,10 @@ class Problem:
             return 'No vendor namespaces set'
         if self.kind == 'invalid-vendor-namespace':
             return 'Invalid vendor namespace'
+        if self.kind == 'invalid-details-url':
+            return 'Invalid details URL'
+        if self.kind == 'invalid-source-url':
+            return 'Invalid source URL'
         return 'Unknown problem %s' % self.kind
 
     @property
@@ -1247,6 +1251,11 @@ class ComponentIssue(db.Model):
     def __repr__(self):
         return '<ComponentIssue {}>'.format(self.value)
 
+def _is_valid_url(url):
+    if not url.startswith('https://') and not url.startswith('http://'):
+        return False
+    return True
+
 class Component(db.Model):
 
     # sqlalchemy metadata
@@ -1504,6 +1513,22 @@ class Component(db.Model):
             problem.url = url_for('.component_show',
                                   component_id=self.component_id,
                                   page='update')
+            problems.append(problem)
+
+        # the URL has to be valid if provided
+        if self.details_url and not _is_valid_url(self.details_url):
+            problem = Problem('invalid-details-url',
+                              'The update details URL was provided but not valid')
+            problem.url = url_for('.component_show',
+                                  page='update',
+                                  component_id=self.component_id)
+            problems.append(problem)
+        if self.source_url and not _is_valid_url(self.source_url):
+            problem = Problem('invalid-source-url',
+                              'The release source URL was provided but not valid')
+            problem.url = url_for('.component_show',
+                                  page='update',
+                                  component_id=self.component_id)
             problems.append(problem)
 
         # the OEM doesn't manage this namespace

--- a/lvfs/templates/firmware-problems.html
+++ b/lvfs/templates/firmware-problems.html
@@ -155,7 +155,7 @@
 {% else %}
     <td class="col col-sm-7">
       <p class="card-text">
-        Please report this issue to the LVFS administrator.
+        {{problem.description}}
       </p>
     </td>
 {% endif %}

--- a/lvfs/tests/lvfs_test.py
+++ b/lvfs/tests/lvfs_test.py
@@ -6,7 +6,7 @@
 # SPDX-License-Identifier: GPL-2.0+
 #
 # pylint: disable=fixme,too-many-public-methods,line-too-long,too-many-lines
-# pylint: disable=too-many-instance-attributes,wrong-import-position
+# pylint: disable=too-many-instance-attributes,wrong-import-position,import-outside-toplevel
 
 import os
 import sys

--- a/plugins/chipsec/__init__.py
+++ b/plugins/chipsec/__init__.py
@@ -93,6 +93,7 @@ class Plugin(PluginBase):
         # run chipsec
         cmd = self.get_setting('chipsec_binary', required=True)
         try:
+            # pylint: disable=unexpected-keyword-arg
             subprocess.check_output([cmd, '--no_driver', 'uefi', 'decode', src.name],
                                     stderr=subprocess.PIPE,
                                     cwd=cwd.name)


### PR DESCRIPTION
Some vendors were setting this to 'n/a' which was being included in the metadata.