### PR TITLE
Allow researchers to run YARA queries on the public firmware

### DIFF
--- a/lvfs/__init__.py
+++ b/lvfs/__init__.py
@@ -135,3 +135,4 @@ from lvfs import views_protocol
 from lvfs import views_category
 from lvfs import views_tests
 from lvfs import views_shard
+from lvfs import views_query

--- a/lvfs/templates/email-modify.txt
+++ b/lvfs/templates/email-modify.txt
@@ -15,6 +15,8 @@ You can now:
  * Add, remove and modify users in the {{user.vendor.group_id}} group
 {% endif %}{% if user.is_approved_public %}
  * Move firmware to the public testing and stable remotes
+{% endif %}{% if user.is_researcher %}
+ * Create YARA rules to run on public firmware
 {% endif %}
 {% if user.auth_type == 'oauth' %}You can access the LVFS by clicking the 'Login' button then using the 'Log in with Azure AD' option.{% endif %}
 You may need to log out and back in before these changes will be applied:

--- a/lvfs/templates/private.html
+++ b/lvfs/templates/private.html
@@ -85,6 +85,11 @@
               <a class="nav-link" href="{{url_for('.issue_all')}}">Known Issues</a>
             </li>
 {% endif %}
+{% if g.user.check_acl('@yara-query') %}
+            <li class="nav-item {{'active' if request.url_rule.endpoint.startswith('query_')}}">
+              <a class="nav-link" href="{{url_for('.query_new')}}">YARA Queries</a>
+            </li>
+{% endif %}
             <li class="nav-item {{'active' if request.url_rule.endpoint == 'metadata_view'}}">
               <a class="nav-link" href="{{url_for('.metadata_view')}}">Metadata</a>
             </li>

--- a/lvfs/templates/query-list.html
+++ b/lvfs/templates/query-list.html
@@ -1,0 +1,50 @@
+{% extends "default.html" %}
+{% block title %}User YARA Queries{% endblock %}
+
+{% block nav %}{% include 'query-nav.html' %}{% endblock %}
+
+{% block content %}
+
+{% if g.user.queries|length == 0 %}
+<div class="card">
+  <div class="card-body">
+  <p class="card-text">
+    No past queries.
+  </p>
+  </div>
+</div>
+{% endif %}
+
+{% for query in g.user.queries %}
+<div class="card mb-3">
+
+  <div class="card-header card-title list-group-item-{{query.color}}">
+    {{query.title}}: {{query.found}} out of {{query.total}}
+    <span class="float-right">{{query.ctime}}</span>
+  </div>
+
+  <div class="card-body">
+{% if query.error %}
+    <pre class="mb-3">{{query.error}}</pre>
+{% endif %}
+{% if query.check_acl('@show') and query.ended_ts %}
+    <a class="card-link btn btn-info"
+       href="{{url_for('.query_show', yara_query_id=query.yara_query_id)}}"
+       role="button">Details</a>
+{% endif %}
+{% if query.check_acl('@retry') and query.started_ts %}
+    <a class="card-link btn btn-warning"
+       href="{{url_for('.query_retry', yara_query_id=query.yara_query_id)}}"
+       role="button">Retry</a>
+{% endif %}
+{% if query.check_acl('@delete') %}
+    <a class="card-link btn btn-danger"
+       href="{{url_for('.query_delete', yara_query_id=query.yara_query_id)}}"
+       role="button">Delete</a>
+{% endif %}
+  </div>
+</div>
+{% endfor %}
+
+{% endblock %}
+

--- a/lvfs/templates/query-nav.html
+++ b/lvfs/templates/query-nav.html
@@ -1,0 +1,20 @@
+<nav class="row">
+  <div class="col col-sm-1 btn-group mb-3">
+{% if request.url_rule.endpoint == 'query_show' %}
+    <a class="btn btn-falcon-default mr-sm-3"
+      href="{{url_for('.query_list')}}">
+      <span class="fas fa-arrow-left"></span>
+    </a>
+{% endif %}
+  </div>
+  <div class="col col-sm-10 text-center mb-3">
+    <div class="btn-group" role="group">
+{% if g.user.check_acl('@yara-query') %}
+      <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'query_new' else 'default'}}"
+        href="{{url_for('.query_new')}}">New Query</a>
+      <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'query_list' else 'default'}}"
+        href="{{url_for('.query_list')}}">Past Queries</a>
+{% endif %}
+    </div>
+  </div>
+</nav>

--- a/lvfs/templates/query-new.html
+++ b/lvfs/templates/query-new.html
@@ -1,0 +1,22 @@
+{% extends "default.html" %}
+{% block title %}Create a YARA Query{% endblock %}
+
+{% block nav %}{% include 'query-nav.html' %}{% endblock %}
+
+{% block content %}
+
+<form method="post" action="{{url_for('.query_add')}}">
+<input type="hidden" name="csrf_token" value="{{csrf_token()}}"/>
+<div class="card mt-3">
+  <div class="card-body">
+    <div class="card-title">Add a new YARA query</div>
+    <div class="form-group">
+      <textarea class="form-control" name="value" value="" placeholder="rule FooBarBaz {" rows="10" required></textarea>
+    </div>
+    <input type="submit" class="btn btn-primary btn-block" value="Add">
+  </div>
+</div>
+</form>
+
+{% endblock %}
+

--- a/lvfs/templates/query-show.html
+++ b/lvfs/templates/query-show.html
@@ -1,0 +1,43 @@
+{% extends "default.html" %}
+{% block title %}User YARA Queries{% endblock %}
+
+{% block nav %}{% include 'query-nav.html' %}{% endblock %}
+
+{% block content %}
+
+<div class="card">
+  <div class="card-body">
+    <pre class="mb-3">{{query.value}}</pre>
+    <a class="card-link btn btn-info"
+       href="{{url_for('.query_retry', yara_query_id=query.yara_query_id)}}"
+       role="button">Retry</a>
+  </div>
+</div>
+
+{% if query.results|length == 0 %}
+<div class="card mt-3">
+  <div class="card-body">
+  <p class="card-text">
+    No matching shards.
+  </p>
+  </div>
+</div>
+{% endif %}
+
+{% for result in query.results %}
+<div class="card mt-3">
+  <div class="card-header card-title list-group-item-{{query.color}}">
+    {{result.shard.md.name_with_category}}: {{result.result}}
+  </div>
+  <div class="card-body">
+    <p>Name: {{result.shard.info.name}}</p>
+    <p>GUID: {{result.shard.info.guid}}</p>
+{% if result.shard.checksum %}
+    <a class="card-link btn btn-info" href="{{url_for('.firmware_shard_search', kind='checksum', value=result.shard.checksum)}}">Show all</a>
+{% endif %}
+  </div>
+</div>
+{% endfor %}
+
+{% endblock %}
+

--- a/lvfs/templates/user-admin.html
+++ b/lvfs/templates/user-admin.html
@@ -117,6 +117,14 @@
           </label>
         </span>
 {% endif %}
+{% if g.user.check_acl('@add-attribute-manager') %}
+        <span class="switch mt-3 mb-3">
+          <input class="switch mt-3" type="checkbox" name="is_researcher" id="is_researcher" value="1" {{'checked' if u.is_researcher}}>
+          <label for="is_researcher">
+            Allowed to create YARA rules that can be run on <strong>public</strong> firmware
+          </label>
+        </span>
+{% endif %}
 {% if g.user.check_acl('@add-attribute-approved') %}
         <span class="switch mt-3">
           <input class="switch" type="checkbox" name="is_approved_public" id="is_approved_public" value="1" {{'checked' if u.is_approved_public}}>

--- a/lvfs/templates/user-nav.html
+++ b/lvfs/templates/user-nav.html
@@ -17,6 +17,10 @@
       <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'user_admin' and page == 'vendor' else 'default'}}"
         href="{{url_for('.user_admin', user_id=u.user_id, page='vendor')}}">Change Vendor</a>
 {% endif %}
+{% if g.user.check_acl('@admin') %}
+      <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'user_queries' else 'default'}}"
+        href="{{url_for('.user_queries', user_id=u.user_id)}}">YARA Queries</a>
+{% endif %}
       <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'user_admin' and page == 'event' else 'default'}}"
         href="{{url_for('.user_admin', user_id=u.user_id, page='event')}}">Event Log</a>
     </div>

--- a/lvfs/templates/user-queries.html
+++ b/lvfs/templates/user-queries.html
@@ -1,0 +1,48 @@
+{% extends "default.html" %}
+{% block title %}User YARA Queries{% endblock %}
+
+{% block nav %}{% include 'user-nav.html' %}{% endblock %}
+
+{% block content %}
+
+{% if u.queries|length == 0 %}
+<div class="card">
+  <div class="card-body">
+    <p class="card-text">
+      No queries have been performed by this user.
+    </p>
+  </div>
+</div>
+{% endif %}
+
+{% for query in u.queries %}
+<div class="card mb-3">
+  <div class="card-header card-title list-group-item-{{query.color}}">
+    {{query.title}}: {{query.found}} out of {{query.total}}
+    <span class="float-right">{{query.ctime}}</span>
+  </div>
+  <div class="card-body">
+    <pre class="mb-3">{{query.value}}</pre>
+{% if query.error %}
+    <pre class="mb-3">{{query.error}}</pre>
+{% endif %}
+{% if query.check_acl('@show') and query.ended_ts %}
+    <a class="card-link btn btn-info"
+       href="{{url_for('.query_show', yara_query_id=query.yara_query_id)}}"
+       role="button">Details</a>
+{% endif %}
+{% if query.check_acl('@retry') and query.started_ts %}
+    <a class="card-link btn btn-warning"
+       href="{{url_for('.query_retry', yara_query_id=query.yara_query_id)}}"
+       role="button">Retry</a>
+{% endif %}
+{% if query.check_acl('@delete') %}
+    <a class="card-link btn btn-danger"
+       href="{{url_for('.query_delete', yara_query_id=query.yara_query_id)}}"
+       role="button">Delete</a>
+{% endif %}
+  </div>
+</div>
+{% endfor %}
+
+{% endblock %}

--- a/lvfs/templates/user-vendor.html
+++ b/lvfs/templates/user-vendor.html
@@ -22,6 +22,9 @@
 {% if u.is_vendor_manager %}
   <input type="hidden" name="is_vendor_manager" value="1">
 {% endif %}
+{% if u.is_researcher %}
+  <input type="hidden" name="is_researcher" value="1">
+{% endif %}
 {% if u.is_approved_public %}
   <input type="hidden" name="is_approved_public" value="1">
 {% endif %}

--- a/lvfs/templates/vendor-users.html
+++ b/lvfs/templates/vendor-users.html
@@ -31,6 +31,7 @@
       {{ 'manager' if u.is_vendor_manager }}
       {{ 'qa' if u.is_qa }}
       {{ 'analyst' if u.is_analyst }}
+      {{ 'researcher' if u.is_researcher }}
       {{ 'otp' if u.is_otp_enabled }}
       </code>
     </td>

--- a/lvfs/views_query.py
+++ b/lvfs/views_query.py
@@ -1,0 +1,132 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
+#
+# SPDX-License-Identifier: GPL-2.0+
+
+from flask import request, flash, url_for, redirect, render_template, g
+from flask_login import login_required
+
+from lvfs import app, db
+
+from .models import YaraQuery
+
+@app.route('/lvfs/query/list')
+@login_required
+def query_list():
+
+    # security check
+    if not g.user.check_acl('@yara-query'):
+        flash('Permission denied: Unable to list queries', 'danger')
+        return redirect(url_for('.dashboard'))
+    return render_template('query-list.html', category='firmware')
+
+@app.route('/lvfs/query/new')
+@login_required
+def query_new():
+
+    # security check
+    if not g.user.check_acl('@yara-query'):
+        flash('Permission denied: Unable to create queries', 'danger')
+        return redirect(url_for('.dashboard'))
+    return render_template('query-new.html', category='firmware')
+
+@app.route('/lvfs/query/<int:yara_query_id>')
+@login_required
+def query_show(yara_query_id):
+
+    # security check
+    if not g.user.check_acl('@yara-query'):
+        flash('Permission denied: Unable to show query', 'danger')
+        return redirect(url_for('.dashboard'))
+
+    # check exists
+    query = db.session.query(YaraQuery).filter(YaraQuery.yara_query_id == yara_query_id).first()
+    if not query:
+        flash('No YARA query found', 'danger')
+        return redirect(url_for('.dashboard'))
+
+    # security check
+    if not query.check_acl('@show'):
+        flash('Permission denied: Unable to show query', 'danger')
+        return redirect(url_for('.dashboard'))
+
+    return render_template('query-show.html', category='firmware', query=query)
+
+@app.route('/lvfs/query/<int:yara_query_id>/retry')
+@login_required
+def query_retry(yara_query_id):
+
+    # security check
+    if not g.user.check_acl('@yara-query'):
+        flash('Permission denied: Unable to retry queries', 'danger')
+        return redirect(url_for('.dashboard'))
+
+    # check exists
+    query = db.session.query(YaraQuery).filter(YaraQuery.yara_query_id == yara_query_id).first()
+    if not query:
+        flash('No query found', 'danger')
+        return redirect(url_for('.dashboard'))
+
+    # security check
+    if not query.check_acl('@retry'):
+        flash('Permission denied: Unable to retry query', 'danger')
+        return redirect(url_for('.dashboard'))
+
+    # renew
+    query.started_ts = None
+    query.ended_ts = None
+    db.session.commit()
+    flash('YARA query {} will be rerun soon'.format(query.yara_query_id), 'info')
+    return redirect(url_for('.query_list'))
+
+@app.route('/lvfs/query/<int:yara_query_id>/delete')
+@login_required
+def query_delete(yara_query_id):
+
+    # security check
+    if not g.user.check_acl('@yara-query'):
+        flash('Permission denied: Unable to delete queries', 'danger')
+        return redirect(url_for('.dashboard'))
+
+    # check exists
+    query = db.session.query(YaraQuery).filter(YaraQuery.yara_query_id == yara_query_id).first()
+    if not query:
+        flash('No query found', 'danger')
+        return redirect(url_for('.dashboard'))
+
+    # security check
+    if not query.check_acl('@delete'):
+        flash('Permission denied: Unable to delete query', 'danger')
+        return redirect(url_for('.dashboard'))
+
+    # renew
+    db.session.delete(query)
+    db.session.commit()
+    flash('Deleted YARA query', 'info')
+    return redirect(url_for('.query_list'))
+
+@app.route('/lvfs/query/add', methods=['POST'])
+@login_required
+def query_add():
+
+    # security check
+    if not g.user.check_acl('@yara-query'):
+        flash('Permission denied: Unable to add queries', 'danger')
+        return redirect(url_for('.dashboard'))
+
+    # sanity check
+    if not 'value' in request.form:
+        flash('Unable to add query as no value', 'danger')
+        return redirect(url_for('.dashboard'))
+    query = db.session.query(YaraQuery).filter(YaraQuery.value == request.form['value']).first()
+    if query:
+        flash('Already a query with that text!', 'info')
+        return redirect(url_for('.query_list'))
+
+    query = YaraQuery(value=request.form['value'], user=g.user)
+    db.session.add(query)
+    db.session.commit()
+    flash('YARA query {} added and will be run soon'.format(query.yara_query_id), 'info')
+    return redirect(url_for('.query_list'), 302)

--- a/migrations/versions/4b78b3c65d57_add_yara_queries.py
+++ b/migrations/versions/4b78b3c65d57_add_yara_queries.py
@@ -1,0 +1,49 @@
+"""
+
+Revision ID: 4b78b3c65d57
+Revises: e0f5f8381a8d
+Create Date: 2019-10-15 19:30:19.318100
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4b78b3c65d57'
+down_revision = 'e0f5f8381a8d'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('yara_query',
+    sa.Column('yara_query_id', sa.Integer(), nullable=False),
+    sa.Column('user_id', sa.Integer(), nullable=False),
+    sa.Column('value', sa.Text(), nullable=True),
+    sa.Column('error', sa.Text(), nullable=True),
+    sa.Column('found', sa.Integer(), nullable=True),
+    sa.Column('total', sa.Integer(), nullable=True),
+    sa.Column('ctime', sa.DateTime(), nullable=False),
+    sa.Column('started_ts', sa.DateTime(), nullable=True),
+    sa.Column('ended_ts', sa.DateTime(), nullable=True),
+    sa.ForeignKeyConstraint(['user_id'], ['users.user_id'], ),
+    sa.PrimaryKeyConstraint('yara_query_id'),
+    sa.UniqueConstraint('yara_query_id'),
+    mysql_character_set='utf8mb4'
+    )
+    op.create_table('yara_query_result',
+    sa.Column('yara_query_result_id', sa.Integer(), nullable=False),
+    sa.Column('yara_query_id', sa.Integer(), nullable=False),
+    sa.Column('component_shard_id', sa.Integer(), nullable=False),
+    sa.Column('result', sa.Text(), nullable=True),
+    sa.ForeignKeyConstraint(['component_shard_id'], ['component_shards.component_shard_id'], ),
+    sa.ForeignKeyConstraint(['yara_query_id'], ['yara_query.yara_query_id'], ),
+    sa.PrimaryKeyConstraint('yara_query_result_id'),
+    sa.UniqueConstraint('yara_query_result_id'),
+    mysql_character_set='utf8mb4'
+    )
+    op.add_column('users', sa.Column('is_researcher', sa.Boolean(), nullable=True))
+
+def downgrade():
+    op.drop_column('users', 'is_researcher')
+    op.drop_table('yara_query_result')
+    op.drop_table('yara_query')


### PR DESCRIPTION
Some security researchers want to run YARA queries on the firmware on the LVFS.
They can (and do) this already, but it means:

 * Downloading tens of gigabytes of firmware using PULP_MANIFEST
 * Exploding each cabinet to get the capsule
 * Exploding each capsule into EFI binaries with chipsec
 * Running yara on the command line

Given the LVFS already has the shards cached for each firmware, just allow
authenticated users to run YARA queries on the public firmware. These are done
in an existing cron job as they typically take a few minutes to compile and run.

It's important to note that this functionality isn't providing anything more
than people can do already with wget and a shell script and so I don't think
it's overstepping the mark allowing carefully chosen security researchers
access to this kind of thing. If anything, I can keep an eye on them this way :)