### PR TITLE
Allow the blocklist plugin to add persistent claims

### DIFF
--- a/lvfs/templates/component-overview.html
+++ b/lvfs/templates/component-overview.html
@@ -173,10 +173,14 @@
       <ul class="list-group">
 {% for attr in md.security_claim.attrs|sort() %}
         <li class="list-group-item">
-{% if not attr.startswith('no') %}
-          <span class="fas fa-check-circle fs-2 text-success"></span>
-{% else %}
+{% if attr.startswith('danger-') %}
           <span class="fas fa-times-circle fs-2 text-danger"></span>
+{% elif attr.startswith('warning-') %}
+          <span class="fas fa-times-circle fs-2 text-warning"></span>
+{% elif attr.startswith('info-') %}
+          <span class="fas fa-info-circle fs-2 text-info"></span>
+{% else %}
+          <span class="fas fa-check-circle fs-2 text-success"></span>
 {% endif %}
           {{md.security_claim.attrs[attr]}}
         </li>

--- a/lvfs/templates/device.html
+++ b/lvfs/templates/device.html
@@ -99,10 +99,14 @@
       <ul class="list-group">
 {% for attr in fw.security_claim.attrs|sort() %}
         <li class="list-group-item">
-{% if not attr.startswith('no') %}
-          <span class="fas fa-check-circle fs-2 text-success"></span>
-{% else %}
+{% if attr.startswith('danger-') %}
           <span class="fas fa-times-circle fs-2 text-danger"></span>
+{% elif attr.startswith('warning-') %}
+          <span class="fas fa-times-circle fs-2 text-warning"></span>
+{% elif attr.startswith('info-') %}
+          <span class="fas fa-info-circle fs-2 text-info"></span>
+{% else %}
+          <span class="fas fa-check-circle fs-2 text-success"></span>
 {% endif %}
           {{fw.security_claim.attrs[attr]}}
         </li>

--- a/migrations/versions/d5d554c30ce4_component_claims.py
+++ b/migrations/versions/d5d554c30ce4_component_claims.py
@@ -1,0 +1,32 @@
+"""
+
+Revision ID: d5d554c30ce4
+Revises: 4b78b3c65d57
+Create Date: 2019-10-24 18:27:33.426659
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd5d554c30ce4'
+down_revision = '4b78b3c65d57'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('component_claims',
+    sa.Column('component_claim_id', sa.Integer(), nullable=False),
+    sa.Column('component_id', sa.Integer(), nullable=False),
+    sa.Column('kind', sa.Text(), nullable=False),
+    sa.Column('value', sa.Text(), nullable=False),
+    sa.ForeignKeyConstraint(['component_id'], ['components.component_id'], ),
+    sa.PrimaryKeyConstraint('component_claim_id'),
+    mysql_character_set='utf8mb4'
+    )
+    op.create_index(op.f('ix_component_claims_component_claim_id'), 'component_claims', ['component_claim_id'], unique=True)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_component_claims_component_claim_id'), table_name='component_claims')
+    op.drop_table('component_claims')

--- a/plugins/blocklist/rules/backdoor-for-nsa.yar
+++ b/plugins/blocklist/rules/backdoor-for-nsa.yar
@@ -4,7 +4,7 @@ rule DualEcBackdoorForNsa
         author = "Richard Hughes <richard@hughsie.com>"
         license = "GPL-2.0+"
         description = "Contains the Dual EC backdoor for the NSA"
-        waivable = false
+        fail = true
 
     strings:
         $str1 = "c97445f45cdef9f0d3e05e1e585fc297235b82b5be8ff3efca67c59852018192" nocase wide ascii

--- a/plugins/blocklist/rules/computrace.yar
+++ b/plugins/blocklist/rules/computrace.yar
@@ -1,0 +1,17 @@
+rule ComputraceAgent
+{
+    meta:
+        license = "GPL-2.0+"
+        description = "Absolute Computrace Agent Executable"
+        fail = false
+        claim = "info-computrace"
+
+    strings:
+        $a = {D1 E0 F5 8B 4D 0C 83 D1 00 8B EC FF 33 83 C3 04}
+        $mz = {4d 5a}
+        $b1 = {72 70 63 6E 65 74 70 2E 65 78 65 00 72 70 63 6E 65 74 70 00}
+        $b2 = {54 61 67 49 64 00}
+
+    condition:
+        ($mz at 0) and ($a or ($b1 and $b2))
+}

--- a/plugins/blocklist/rules/ibv-example-certificate.yar
+++ b/plugins/blocklist/rules/ibv-example-certificate.yar
@@ -4,7 +4,7 @@ rule IbvExampleCertificate
         author = "Richard Hughes <richard@hughsie.com>"
         license = "GPL-2.0+"
         description = "IBV example certificate being used"
-        waivable = false
+        fail = true
 
     strings:
         $str1 = "DO NOT TRUST" nocase wide ascii

--- a/plugins/blocklist/rules/ibv-example-dmi-data.yar
+++ b/plugins/blocklist/rules/ibv-example-dmi-data.yar
@@ -4,7 +4,7 @@ rule IbvExampleDmi
         author = "Richard Hughes <richard@hughsie.com>"
         license = "GPL-2.0+"
         description = "IBV example DMI being used"
-        waivable = true
+        fail = true
 
     strings:
         $str1 = "To Be Defined By O.E.M" nocase wide ascii


### PR DESCRIPTION
This could be used for instance to detect Computrace, BootGuard or BIOSguard,
and used to provide helpful user information to the device model.