### PR TITLE
Allow syncing with other firmware databases

### DIFF
--- a/lvfs/__init__.py
+++ b/lvfs/__init__.py
@@ -55,6 +55,7 @@ from lvfs.analytics.routes import bp_analytics
 from lvfs.categories.routes import bp_categories
 from lvfs.components.routes import bp_components
 from lvfs.devices.routes import bp_devices
+from lvfs.mdsync.routes import bp_mdsync
 from lvfs.docs.routes import bp_docs
 from lvfs.firmware.routes import bp_firmware
 from lvfs.issues.routes import bp_issues
@@ -78,6 +79,7 @@ app.register_blueprint(bp_analytics, url_prefix='/lvfs/analytics')
 app.register_blueprint(bp_categories, url_prefix='/lvfs/categories')
 app.register_blueprint(bp_components, url_prefix='/lvfs/components')
 app.register_blueprint(bp_devices, url_prefix='/lvfs/devices')
+app.register_blueprint(bp_mdsync, url_prefix='/lvfs/mdsync')
 app.register_blueprint(bp_docs, url_prefix='/lvfs/docs')
 app.register_blueprint(bp_firmware, url_prefix='/lvfs/firmware')
 app.register_blueprint(bp_issues, url_prefix='/lvfs/issues')

--- a/lvfs/mdsync/routes.py
+++ b/lvfs/mdsync/routes.py
@@ -1,0 +1,282 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
+#
+# SPDX-License-Identifier: GPL-2.0+
+
+import json
+
+from collections import defaultdict
+import dateutil.parser
+
+from flask import Blueprint, request, url_for, redirect, flash, Response, render_template, g
+from flask_login import login_required
+
+from lvfs import db, csrf
+
+from lvfs.models import Firmware, Component, Remote, ComponentRef, Protocol, Vendor
+from lvfs.util import _json_success, _json_error
+
+bp_mdsync = Blueprint('mdsync', __name__, template_folder='templates')
+
+def _md_to_mdsync_dict(md):
+    obj = {}
+    obj['component_id'] = md.component_id
+    obj['status'] = md.fw.remote.icon_name
+    if md.fw.remote.is_public:
+        obj['date'] = md.fw.signed_timestamp.isoformat()
+        if md.release_tag:
+            obj['release_tag'] = md.release_tag
+        if md.details_url:
+            obj['changelog_url'] = md.details_url
+    return obj
+
+def _mds_to_mdsync_dict(mds):
+    obj = {}
+    for md in sorted(mds):
+        if not md.fw.vendor.visible:
+            continue
+        obj[md.version_display] = _md_to_mdsync_dict(md)
+    return obj
+
+def _any_public(mds):
+    for md in mds:
+        if md.fw.remote.is_public:
+            return True
+    return False
+
+@bp_mdsync.route('/export')
+@csrf.exempt
+@login_required
+def route_export():
+
+    # security check
+    if not g.user.check_acl('@partner'):
+        return _json_error('Permission denied: Unable to export data')
+
+    # get a dict of all stable components, with the appstream-id as dedupe-key
+    mds_by_ids = defaultdict(list)
+    for md in db.session.query(Component).\
+                    join(Firmware).\
+                    join(Remote).\
+                    filter(Remote.name != 'private',
+                           Remote.name != 'deleted').\
+                    order_by(Component.appstream_id):
+        mds_by_ids[md.appstream_id].append(md)
+
+    # export the devices
+    obj_devs = []
+    for mds_by_id in mds_by_ids:
+        obj_dev = {}
+
+        # don't include devices that have not had a single public release
+        mds = mds_by_ids[mds_by_id]
+        if not _any_public(mds):
+            continue
+
+        # assume these are all the same
+        md_first = mds[0]
+        obj_dev['appstream_id'] = md_first.appstream_id
+        obj_dev['names'] = md_first.names
+        if md_first.protocol:
+            obj_dev['protocol'] = md_first.protocol.value
+
+        # add different versions
+        obj_dev['versions'] = _mds_to_mdsync_dict(mds_by_ids[mds_by_id])
+        obj_devs.append(obj_dev)
+    blob = {}
+    blob['metadata'] = {'version': 0}
+    blob['devices'] = obj_devs
+    dat = json.dumps(blob, indent=4, separators=(',', ': '))
+    return Response(response=dat,
+                    status=400, \
+                    mimetype="application/json")
+
+def _get_plausible_versions_for_md(md):
+    versions = [md.version_display]
+    if md.version not in versions:
+        versions.append(md.version)
+    if md.version_display.startswith('0.'):
+        versions.append(md.version_display[2:])
+    return versions
+
+@bp_mdsync.route('/import', methods=['POST'])
+@csrf.exempt
+@login_required
+def route_import():
+
+    # security check
+    if not g.user.check_acl('@partner'):
+        return _json_error('Permission denied: Unable to import data')
+
+    # parse JSON data
+    try:
+        payload = request.data.decode('utf8')
+        obj = json.loads(payload)
+    except ValueError as e:
+        return _json_error('No JSON object could be decoded: ' + str(e))
+
+    # get available protocols
+    protocols = {}
+    for protocol in db.session.query(Protocol):
+        protocols[protocol.value] = protocol
+
+    # get available components
+    mds_by_id = {}
+    mds_by_tag = {}
+    mds_by_ver = {}
+    for md in db.session.query(Component).\
+                            join(Firmware).\
+                            join(Remote).\
+                            filter(Remote.name != 'private',
+                                   Remote.name != 'deleted'):
+        mds_by_id[md.component_id] = md
+        for version in _get_plausible_versions_for_md(md):
+            mds_by_ver['{}/{}'.format(md.appstream_id, version)] = md
+        if md.release_tag:
+            mds_by_tag['{}/{}'.format(md.appstream_id, md.release_tag.casefold())] = md
+
+    # parse blob
+    mdrefs = []
+    try:
+        if 'metadata' not in obj:
+            return _json_error('metadata object missing')
+        metadata = obj['metadata']
+        if metadata['version'] != 0:
+            return _json_error('metadata schema version unsupported: ' + str(e))
+        for obj_dev in obj['devices']:
+
+            # required, but may be junk for devices not in LVFS
+            appstream_id = obj_dev['appstream_id']
+
+            # has to match something specified on the LVFS if specified
+            if 'protocol' in obj_dev:
+                protocol = protocols.get(obj_dev['protocol'], None)
+            else:
+                protocol = None
+
+            # squash this together as one string as it's only used for analysis
+            name = '/'.join(obj_dev.get('names', []))
+
+            # parse each version for the model
+            for version in obj_dev['versions']:
+                obj_ver = obj_dev['versions'][version]
+
+                # the component_id is optional, but allows the LVFS to link FW
+                md = None
+                if 'component_id' in obj_ver:
+                    md = mds_by_id.get(obj_ver['component_id'], None)
+
+                # try getting the md using the appstream-id and the version
+                if not md:
+                    md = mds_by_ver.get('{}/{}'.format(appstream_id, version), None)
+
+                # try getting the md using the release tag
+                release_tag = obj_ver.get('release_tag', None)
+                if release_tag and release_tag.find('_') != -1:
+                    # this will be fixed by the importer...
+                    release_tag = None
+                if not md and release_tag:
+                    md = mds_by_tag.get('{}/{}'.format(appstream_id, release_tag.casefold()), None)
+
+                # date has to be in ISO8601 format
+                date = None
+                if 'date' in obj_ver:
+                    date = dateutil.parser.parse(obj_ver['date'])
+
+                # prefer the changelog url
+                url = obj_ver.get('changelog_url', None)
+                if not url:
+                    url = obj_ver.get('file_url', None)
+                mdref = ComponentRef(appstream_id=appstream_id,
+                                     version=version,
+                                     date=date,
+                                     md=md,
+                                     status=obj_ver.get('status', None),
+                                     release_tag=release_tag,
+                                     url=url,
+                                     name=name,
+                                     vendor=g.user.vendor,
+                                     protocol=protocol)
+                mdrefs.append(mdref)
+    except KeyError as e:
+        return _json_error('JSON invalid: ' + str(e))
+
+    # delete all old mdrefs from this vendor
+    for mdref in db.session.query(ComponentRef).\
+                    filter(ComponentRef.vendor_id == g.user.vendor_id):
+        db.session.delete(mdref)
+    db.session.commit()
+
+    # add all new mdrefs
+    for mdref in mdrefs:
+        db.session.add(mdref)
+    db.session.commit()
+
+    return _json_success()
+
+@bp_mdsync.route('/')
+@login_required
+def route_list():
+
+    # security check
+    if not g.user.check_acl('@vendor-manager'):
+        return redirect(url_for('main.route_dashboard'), 302)
+
+    # we're just showing public vendors on the LVFS
+    # and firmware scraped from other public sources
+    if g.user.check_acl('@admin'):
+        vendors = db.session.query(Vendor).\
+                        join(ComponentRef).\
+                        filter(ComponentRef.vendor_id).all()
+    else:
+        vendors = db.session.query(Vendor).\
+                        filter(Vendor.visible).\
+                        join(ComponentRef).\
+                        filter(ComponentRef.vendor_id).all()
+    return render_template('mdsync-list.html',
+                           category='telemetry',
+                           vendors=vendors)
+
+def _has_any_prefix(items, text):
+    for item in items:
+        if text.startswith(item):
+            return True
+    return False
+
+@bp_mdsync.route('/<int:vendor_id>')
+@login_required
+def route_show(vendor_id):
+
+    # security check
+    if not g.user.check_acl('@vendor-manager'):
+        return redirect(url_for('main.route_dashboard'), 302)
+
+    # another security check
+    vendor = db.session.query(Vendor).filter(Vendor.vendor_id == vendor_id).first()
+    if not vendor or not vendor.visible:
+        flash('Failed to get vendor details: No a vendor with that ID', 'warning')
+        return redirect(url_for('mdsync.route_list'), 302)
+
+    # create filtered list using the namespace
+    mdrefs_by_id = defaultdict(list)
+    md_by_id = {}
+    namespaces = [ns.value for ns in g.user.vendor.namespaces]
+    for mdref in vendor.mdrefs:
+        if not g.user.check_acl('@admin'):
+            if not _has_any_prefix(namespaces, mdref.appstream_id):
+                continue
+        if mdref.appstream_id:
+            mdrefs_by_id[mdref.appstream_id].append(mdref)
+        else:
+            mdrefs_by_id['unknown'].append(mdref)
+        if mdref.md and mdref.appstream_id:
+            md_by_id[mdref.appstream_id] = mdref.md
+
+    return render_template('mdsync-show.html',
+                           category='telemetry',
+                           v=vendor,
+                           namespaces=namespaces,
+                           md_by_id=md_by_id,
+                           mdrefs_by_id=mdrefs_by_id)

--- a/lvfs/mdsync/routes_test.py
+++ b/lvfs/mdsync/routes_test.py
@@ -1,0 +1,115 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
+#
+# SPDX-License-Identifier: GPL-2.0+
+#
+# pylint: disable=wrong-import-position,singleton-comparison
+
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath('.'))
+
+from lvfs.testcase import LvfsTestCase
+
+class LocalTestCase(LvfsTestCase):
+
+    def test_mdsync(self):
+
+        # upload a firmware that can receive a report
+        self.login()
+        self.add_namespace()
+        self.upload(target='testing')
+
+        # mark vendor as visible
+        rv = self.app.post('/lvfs/vendors/1/modify_by_admin', data=dict(
+            visible='1',
+        ), follow_redirects=True)
+        assert b'Updated vendor' in rv.data, rv.data
+
+        # become partner to the LVFS
+        rv = self.app.post('/lvfs/users/1/modify_by_admin',
+                           data={'admin': '1',
+                                 'qa': '1',
+                                 'vendor-manager': '1',
+                                 'partner': '1'},
+                           follow_redirects=True)
+        assert b'Updated profile' in rv.data, rv.data
+
+        # move to stable
+        self.run_cron_firmware()
+        rv = self.app.get('/lvfs/firmware/1/promote/stable',
+                          follow_redirects=True)
+        assert b'>stable<' in rv.data, rv.data.decode()
+
+        # get the LVFS world-view
+        rv = self.app.get('/lvfs/mdsync/export')
+        assert b'com.hughski.ColorHug2.firmware' in rv.data, rv.data.decode()
+        assert b'com.hughski.colorhug' in rv.data, rv.data.decode()
+        assert b'2.0.3' in rv.data, rv.data.decode()
+
+        # import another world-view
+        payload = """
+{
+    "devices": [
+        {
+            "appstream_id": "com.hughski.ColorHug2.firmware",
+            "names": [
+                "ColorHug2"
+            ],
+            "protocol": "com.hughski.colorhug",
+            "versions": {
+                "2.0.999": {
+                    "component_id": 1,
+                    "status": "stable"
+                }
+            }
+        },
+        {
+            "appstream_id": "com.hughski.ColorHug3.firmware",
+            "names": [
+                "ColorHug3"
+            ],
+            "protocol": "org.usb.dfu",
+            "versions": {
+                "1.0.0": {
+                    "changelog_url": "https://download.hughski.com/pccbbs/mobiles/r0suj04w.txt",
+                    "date": "2019-06-14T00:00:00.000Z",
+                    "release_tag": "r0suj04w",
+                    "status": "testing"
+                }
+            }
+        },
+        {
+            "appstream_id": "com.hughski.ColorHug4.firmware",
+            "versions": {
+                "1.2.3": {
+                }
+            }
+        }
+    ],
+    "metadata": {
+        "version": 0
+    }
+}
+"""
+        rv = self.app.post('/lvfs/mdsync/import', data=payload, follow_redirects=True)
+        assert b'"success": true' in rv.data, rv.data.decode()
+
+        # list all vendors with different world-views
+        rv = self.app.get('/lvfs/mdsync/', follow_redirects=True)
+        assert b'Acme Corp' in rv.data, rv.data.decode()
+
+        # all firmware known by Acme Corp.
+        rv = self.app.get('/lvfs/mdsync/1', follow_redirects=True)
+        assert b'com.hughski.ColorHug2.firmware' in rv.data, rv.data.decode()
+        assert b'com.hughski.ColorHug3.firmware' in rv.data, rv.data.decode()
+        assert b'com.hughski.ColorHug4.firmware' in rv.data, rv.data.decode()
+        assert b'download.hughski.com' in rv.data, rv.data.decode()
+        assert b'/lvfs/components/1' in rv.data, rv.data.decode()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lvfs/mdsync/templates/mdsync-list.html
+++ b/lvfs/mdsync/templates/mdsync-list.html
@@ -1,0 +1,38 @@
+{% extends "default.html" %}
+
+{% block title %}Partner Metadata{% endblock %}
+
+{% block content %}
+
+<div class="card mt-3">
+  <div class="card-body">
+    <div class="card-title">Partner Metadata</div>
+{% if vendors|length == 0 %}
+    <p class="card-text text-muted">No vendors have contributed metadata.</p>
+{% else %}
+    <p class="card-text">
+      External teams contribute metadata about firmware releases from public
+      sources such as a vendor home page.
+    </p>
+{% endif %}
+  </div>
+</div>
+
+{% for v in vendors %}
+<div class="card mt-3" id="{{v.group_id}}">
+  <div class="card-body">
+    <div class="card-title">
+      {{v.display_name}}
+{% if v.icon %}
+      <img class="img-thumbnail float-right" src="/uploads/{{v.icon}}" width="96"/>
+{% else %}
+      <img class="img-thumbnail float-right" src="/uploads/vendor-unknown.png" width="96"/>
+{% endif %}
+    </div>
+    <p class="card-text">{{v.description}}</p>
+    <a class="card-link btn btn-primary mt-3" href="{{url_for('mdsync.route_show', vendor_id=v.vendor_id)}}">Show devices</a>
+  </div>
+</div>
+{% endfor %}
+
+{% endblock %}

--- a/lvfs/mdsync/templates/mdsync-nav.html
+++ b/lvfs/mdsync/templates/mdsync-nav.html
@@ -1,0 +1,8 @@
+<nav class="row">
+  <div class="col col-sm-1 btn-group mb-3">
+    <a class="btn btn-falcon-default mr-sm-3"
+      href="{{url_for('mdsync.route_list')}}">
+      <span class="fas fa-arrow-left"></span>
+    </a>
+  </div>
+</nav>

--- a/lvfs/mdsync/templates/mdsync-show.html
+++ b/lvfs/mdsync/templates/mdsync-show.html
@@ -1,0 +1,124 @@
+{% extends "default.html" %}
+
+{% block title %}Partner Metadata collected by {{v.display_name}}{% endblock %}
+
+{% block nav %}{% include 'mdsync-nav.html' %}{% endblock %}
+
+{% block content %}
+
+<div class="alert alert-info" role="alert">
+  All metadata on this page has been contributed by {{v.display_name}} and the
+  LVFS team has not validated if the information here is correct.
+</div>
+
+{% if not mdrefs_by_id %}
+<div class="alert alert-secondary" role="alert">
+  No metadata is visible for this vendor.</p>
+</div>
+{% endif %}
+
+<div class="card mb-3" id="{appsteam_id}}">
+  <div class="card-body">
+    <div class="card-title">
+      Summary for all models
+    </div>
+    <ul class="list-group">
+{% for appstream_id in mdrefs_by_id|sort %}
+{% set mdrefs = mdrefs_by_id[appstream_id]|sort %}
+{% set mdref_last = mdrefs[-1] %}
+{% set md = md_by_id.get(appstream_id, None) %}
+{% if md %}
+      <li class="list-group-item">
+{% set mdrefmd = mdref_last.md %}
+{% if mdrefmd and mdrefmd.fw.remote.is_public %}
+        <span class="fas fa-check-circle fs-2 text-success mr-2"></span>
+        <a href="#{{appstream_id}}">
+         {{md.fw.vendor.display_name}} {{md.name_with_category}} ({{md.version_display}})
+        </a>
+{% else %}
+        <span class="fas fa-times-circle fs-2 text-danger mr-2"></span>
+        <a href="#{{appstream_id}}">
+         {{md.fw.vendor.display_name}} {{md.name_with_category}} ({{md.version_display}} != {{mdref_last.version}})
+        </a>
+      </li>
+{% endif %}
+{% endif %}
+{% endfor %}
+    </ul>
+  </div>
+</div>
+
+{% for appstream_id in mdrefs_by_id %}
+{% set mdrefs = mdrefs_by_id[appstream_id] %}
+{% if not mdrefs %}
+    <p class="card-text text-muted">No mdrefs for {{appstream_id}}.</p>
+{% else %}
+<a name="{{appstream_id}}"></a>
+<div class="card mb-3" id="{appsteam_id}}">
+  <div class="card-body">
+    <div class="card-title">
+{% set md = md_by_id.get(appstream_id, None) %}
+{% if md %}
+      {{md.fw.vendor.display_name}} {{md.name_with_category}}
+{% else %}
+      {{mdrefs[0].name or 'Unknown'}}
+{% endif %}
+      <code class="float-right">{{appstream_id}}</code>
+    </div>
+{% for mdref in mdrefs|sort %}
+    <h3>
+{% if mdref.md and mdref.md.fw.remote.is_public %}
+      <span class="fas fa-check-circle fs-2 text-success"></span>
+      <a href="{{url_for('components.route_show', component_id=mdref.md.component_id)}}">
+        {{mdref.version}}
+      </a>
+{% elif mdref.md %}
+      <span class="fas fa-times-circle fs-2 text-warning"></span>
+      <a href="{{url_for('components.route_show', component_id=mdref.md.component_id)}}">
+        {{mdref.version}}
+      </a>
+{% else %}
+      <span class="fas fa-times-circle fs-2 text-danger"></span>
+      {{mdref.version}}
+{% endif %}
+    </h3>
+<table class="card-text table">
+{% if mdref.url %}
+  <tr class="row">
+    <th class="col-3">Vendor URL</th>
+    <td class="col">
+      <a href="{{mdref.url}}">{{mdref.url}}</a>
+    </td>
+  </tr>
+{% endif %}
+{% if mdref.release_tag %}
+  <tr class="row">
+    <th class="col-3">Release Tag</th>
+    <td class="col"><code class="text-uppercase">{{mdref.release_tag}}</code></td>
+  </tr>
+{% endif %}
+{% if mdref.date %}
+  <tr class="row">
+    <th class="col-3">Public Release</th>
+    <td class="col">{{mdref.date.strftime('%Y-%m-%d')}}</td>
+  </tr>
+{% endif %}
+{% if mdref.status %}
+  <tr class="row">
+    <th class="col-3">OEM State</th>
+    <td class="col">
+      <img src="/img/symbolic-{{mdref.status}}.svg" width="24"
+        alt="{{mdref.status}}"
+        title="{{mdref.status}}"/>
+      {{mdref.status}}
+    </td>
+  </tr>
+{% endif %}
+</table>
+{% endfor %}
+  </div>
+</div>
+{% endif %}
+{% endfor %}
+
+{% endblock %}

--- a/lvfs/templates/private.html
+++ b/lvfs/templates/private.html
@@ -118,6 +118,11 @@
             <li class="nav-item {{'active' if request.url_rule.endpoint == 'telemetry' and age==180}}">
               <a class="nav-link" href="{{url_for('telemetry.route_show', age=180)}}">Last 6 months</a>
             </li>
+{% if g.user.check_acl('@vendor-manager') %}
+            <li class="nav-item {{'active' if request.url_rule.endpoint.startswith('mdsync.route')}}">
+              <a class="nav-link" href="{{url_for('mdsync.route_list')}}">Partner Metadata</a>
+            </li>
+{% endif %}
           </ul>
         </li>
 {% endif %}

--- a/lvfs/users/routes.py
+++ b/lvfs/users/routes.py
@@ -331,6 +331,10 @@ def route_modify_by_admin(user_id):
         if not g.user.check_acl('@add-action-admin'):
             flash('Permission denied: Unable to mark user as admin', 'danger')
             return redirect(url_for('main.route_dashboard'))
+    if not user.check_acl('@admin') and 'partner' in request.form:
+        if not g.user.check_acl('@add-action-partner'):
+            flash('Permission denied: Unable to mark user as partner', 'danger')
+            return redirect(url_for('main.route_dashboard'))
 
     # set each optional thing in turn
     old_vendor = user.vendor
@@ -358,7 +362,7 @@ def route_modify_by_admin(user_id):
     for key in ['is_otp_enabled']:
         setattr(user, key, bool(key in request.form))
     for key in ['qa', 'analyst', 'vendor-manager', 'researcher',
-                'approved-public', 'robot', 'admin']:
+                'approved-public', 'robot', 'admin', 'partner']:
         if key in request.form:
             if not user.get_action(key):
                 user.actions.append(UserAction(value=key))

--- a/lvfs/users/templates/user-admin.html
+++ b/lvfs/users/templates/user-admin.html
@@ -131,6 +131,15 @@
         </span>
         <br/>
 {% endif %}
+{% if g.user.check_acl('@add-action-partner') %}
+        <span class="switch mt-3 mb-3">
+          <input class="switch mt-3" type="checkbox" name="partner" id="partner" value="1" {{'checked' if u.check_acl('@partner')}}>
+          <label for="partner">
+            Allowed to import and export <strong>public</strong> lists of firmware, e.g. from Microsoft Update
+          </label>
+        </span>
+        <br/>
+{% endif %}
 {% if g.user.check_acl('@add-action-approved-public') %}
         <span class="switch mt-3">
           <input class="switch" type="checkbox" name="approved-public" id="approved-public" value="1" {{'checked' if u.check_acl('@approved-public')}}>

--- a/migrations/versions/9b46ff543492_component_ref.py
+++ b/migrations/versions/9b46ff543492_component_ref.py
@@ -1,0 +1,40 @@
+"""
+
+Revision ID: 9b46ff543492
+Revises: 05217bb7d0c0
+Create Date: 2019-11-13 14:06:41.553762
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '9b46ff543492'
+down_revision = '13c307a09ff1'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('component_refs',
+    sa.Column('component_ref_id', sa.Integer(), nullable=False),
+    sa.Column('component_id', sa.Integer(), nullable=True),
+    sa.Column('vendor_id', sa.Integer(), nullable=False),
+    sa.Column('protocol_id', sa.Integer(), nullable=True),
+    sa.Column('appstream_id', sa.Text(), nullable=True),
+    sa.Column('version', sa.Text(), nullable=False),
+    sa.Column('release_tag', sa.Text(), nullable=True),
+    sa.Column('date', sa.DateTime(), nullable=True),
+    sa.Column('name', sa.Text(), nullable=False),
+    sa.Column('url', sa.Text(), nullable=True),
+    sa.Column('status', sa.Text(), nullable=True),
+    sa.ForeignKeyConstraint(['component_id'], ['components.component_id'], ),
+    sa.ForeignKeyConstraint(['protocol_id'], ['protocol.protocol_id'], ),
+    sa.ForeignKeyConstraint(['vendor_id'], ['vendors.vendor_id'], ),
+    sa.PrimaryKeyConstraint('component_ref_id'),
+    mysql_character_set='utf8mb4'
+    )
+    op.create_index(op.f('ix_component_refs_component_ref_id'), 'component_refs', ['component_ref_id'], unique=True)
+
+def downgrade():
+    op.drop_index(op.f('ix_component_refs_component_ref_id'), table_name='component_refs')
+    op.drop_table('component_refs')


### PR DESCRIPTION
External teams can contribute metadata about firmware releases from public
sources such as a vendor homepage or the general list downloaded from
Windows Update. This functionality allows us to check both that models have
been included on the LVFS and that matching versions are present.

Vendor managers are allowed to view this data, but only if the appstream ID
matches one of their assigned namespace prefixes.