### PR TITLE
Add a release tag to store the vendor-specific firmware identifier

### DIFF
--- a/lvfs/components/routes.py
+++ b/lvfs/components/routes.py
@@ -168,6 +168,8 @@ def route_modify(component_id):
         md.name = request.form['name']
     if 'name_variant_suffix' in request.form:
         md.name_variant_suffix = request.form['name_variant_suffix']
+    if 'release_tag' in request.form:
+        md.release_tag = request.form['release_tag']
 
     # the firmware changed protocol
     if retry_all_tests:

--- a/lvfs/components/templates/component-overview.html
+++ b/lvfs/components/templates/component-overview.html
@@ -57,6 +57,22 @@
 {% endif %}
   </tr>
   <tr class="row">
+    <th class="col-3">Tag, e.g. <code>N1CET75W</code> (optional)</th>
+{% if md.check_acl('@modify-keywords') %}
+    <form class="form-inline" action="{{url_for('components.route_modify', component_id=md.component_id)}}" method="POST">
+    <input type="hidden" name="csrf_token" value="{{csrf_token()}}"/>
+    <td class="col-7">
+      <textarea class="form-control fixed-width" name="release_tag" cols="100" rows="1">{{md.release_tag if md.release_tag}}</textarea>
+    </td>
+    <td class="col">
+      <input type="submit" class="btn btn-warning btn-block" value="Set"/>
+    </td>
+    </form>
+{% else %}
+    <td class="col"><code>{{md.release_tag}}</code></td>
+{% endif %}
+  </tr>
+  <tr class="row">
     <th class="col-3">Summary</th>
     <td class="col"><code>{{md.summary}}</code></td>
   </tr>

--- a/lvfs/docs/templates/docs-metainfo-style.html
+++ b/lvfs/docs/templates/docs-metainfo-style.html
@@ -95,4 +95,23 @@
   </div>
 </div>
 
+<div class="card mt-3">
+  <div class="card-body">
+    <div class="card-title"><code>&lt;release tag="N1NET43W" &hellip;&gt;</code></div>
+    <ul class="card-text">
+      <li>
+        The release tag is <strong>optional</strong>, but can used to show a
+        vendor-specific text identifier that is different from the version number.
+      </li>
+      <li>
+        The tag may be unique only to the model, or be unique for the entire vendor.
+      </li>
+      <li>
+        This attribute should not be used if the tag is not used to identify the
+        specific firmware on the vendor homepage.
+      </li>
+    </ul>
+  </div>
+</div>
+
 {% endblock %}

--- a/lvfs/firmware/templates/firmware-components.html
+++ b/lvfs/firmware/templates/firmware-components.html
@@ -19,7 +19,7 @@
       </div>
     </div>
     <p class="card-text">
-      <small class="text-muted">Version: {{md.version_display}}</small>
+      <small class="text-muted">Version: {{md.version_with_tag}}</small>
     </p>
     <a class="card-link btn btn-info" href="{{url_for('components.route_show', component_id=md.component_id)}}">Details</a>
   </div>

--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -1449,6 +1449,7 @@ class Component(db.Model):
     release_installed_size = Column(Integer, default=0)
     release_download_size = Column(Integer, default=0)
     release_urgency = Column(Text, default=None)
+    release_tag = Column(Text, default=None)
     screenshot_url = Column(Text, default=None)
     screenshot_caption = Column(Text, default=None)
     inhibit_download = Column(Boolean, default=False)
@@ -1606,6 +1607,12 @@ class Component(db.Model):
         if self.project_license.find('GPL') != -1:
             return True
         return False
+
+    @property
+    def version_with_tag(self):
+        if self.release_tag:
+            return '{} ({})'.format(self.release_tag, self.version_display)
+        return self.version_display
 
     @property
     def version_display(self):

--- a/lvfs/upload/uploadedfile.py
+++ b/lvfs/upload/uploadedfile.py
@@ -226,6 +226,13 @@ class UploadedFile:
         else:
             raise MetadataInvalid('<release> had no date or timestamp attributes')
 
+        # optional release tag
+        if 'tag' in release.attrib:
+            md.release_tag = release.attrib['tag']
+            if len(md.release_tag) < 4:
+                raise MetadataInvalid('<release> tag was too short to identify the firmware')
+            md.add_keywords_from_string(md.release_tag, priority=5)
+
         # get list of CVEs
         for issue in release.xpath('issues/issue'):
             kind = issue.get('type')

--- a/lvfs/upload/uploadedfile_test.py
+++ b/lvfs/upload/uploadedfile_test.py
@@ -25,7 +25,8 @@ from cabarchive import CabArchive, CabFile
 def _get_valid_firmware():
     return CabFile('fubar'.ljust(1024).encode('utf-8'))
 
-def _get_valid_metainfo(release_description='This stable release fixes bugs',
+def _get_valid_metainfo(release_tag='N1NET43W',
+                        release_description='This stable release fixes bugs',
                         version_format='quad', enable_inf_parsing=True):
     txt = """<?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2015 Richard Hughes <richard@hughsie.com> -->
@@ -43,7 +44,7 @@ def _get_valid_metainfo(release_description='This stable release fixes bugs',
   <project_license>GPL-2.0+</project_license>
   <developer_name>Hughski Limited</developer_name>
   <releases>
-    <release version="0x30002" timestamp="1424116753">
+    <release version="0x30002" timestamp="1424116753" tag="%s">
       <description><p>%s</p></description>
     </release>
   </releases>
@@ -54,7 +55,7 @@ def _get_valid_metainfo(release_description='This stable release fixes bugs',
     <value key="LVFS::EnableInfParsing">%s</value>
   </custom>
 </component>
-""" % (release_description, version_format, str(enable_inf_parsing).lower())
+""" % (release_tag, release_description, version_format, str(enable_inf_parsing).lower())
     return CabFile(txt.encode('utf-8'))
 
 def _get_alternate_metainfo():
@@ -296,6 +297,16 @@ class TestStringMethods(unittest.TestCase):
         cabarchive = CabArchive()
         cabarchive['firmware.bin'] = _get_valid_firmware()
         cabarchive['firmware.metainfo.xml'] = _get_valid_metainfo(version_format='foo')
+        with self.assertRaises(MetadataInvalid):
+            ufile = UploadedFile()
+            _add_version_formats(ufile)
+            ufile.parse('foo.cab', cabarchive.save())
+
+    # invalid release tag
+    def test_invalid_release_tag(self):
+        cabarchive = CabArchive()
+        cabarchive['firmware.bin'] = _get_valid_firmware()
+        cabarchive['firmware.metainfo.xml'] = _get_valid_metainfo(release_tag='foo')
         with self.assertRaises(MetadataInvalid):
             ufile = UploadedFile()
             _add_version_formats(ufile)

--- a/migrations/versions/ae8f6b33ba7d_component_release_id.py
+++ b/migrations/versions/ae8f6b33ba7d_component_release_id.py
@@ -1,0 +1,21 @@
+"""
+
+Revision ID: ae8f6b33ba7d
+Revises: 946c9e47ceaa
+Create Date: 2019-12-03 21:14:10.737816
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'ae8f6b33ba7d'
+down_revision = '946c9e47ceaa'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('components', sa.Column('release_tag', sa.Text(), nullable=True))
+
+def downgrade():
+    op.drop_column('components', 'release_tag')


### PR DESCRIPTION
This could be used, for instance, by Lenovo to specify a tag of `N1NET43W` for
a specific firmware release.