### PR TITLE
Include a vendor ID by default for testing accounts

### DIFF
--- a/lvfs/main/templates/dashboard.html
+++ b/lvfs/main/templates/dashboard.html
@@ -24,6 +24,14 @@
 </div>
 {% endif %}
 
+{% if not g.user.vendor.restrictions %}
+<div class="alert alert-warning mb-3" role="alert">
+  This account has no vendor restrictions defined and firmware will not be
+  deployed onto hardware.
+  Please contact the <a href="mailto:info@fwupd.org">LVFS administrator</a>.
+</div>
+{% endif %}
+
 {% if not g.user.vendor.do_not_track and download_cnt > 0 %}
 <div class="card">
   <div class="card-body rounded-soft bg-gradient">

--- a/lvfs/metadata/utils.py
+++ b/lvfs/metadata/utils.py
@@ -63,7 +63,7 @@ def _generate_metadata_kind(filename, fws, firmware_baseuri='', local=False):
                 break
 
             # the vendor can upload to any hardware
-            vendor = md.fw.vendor
+            vendor = md.fw.vendor_odm
             if vendor.is_unrestricted:
                 continue
 

--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -744,6 +744,10 @@ class Vendor(db.Model):
             if user.vendor_id != self.vendor_id:
                 return False
             return user.check_acl('@vendor-manager')
+        if action == '@view-restrictions':
+            if user.vendor_id != self.vendor_id:
+                return False
+            return user.check_acl('@vendor-manager')
         if action == '@modify-affiliations':
             return False
         if action == '@modify-affiliation-actions':

--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -655,6 +655,13 @@ class Vendor(db.Model):
         return self.users
 
     @property
+    def is_unrestricted(self):
+        for res in self.restrictions:
+            if res.value == '*':
+                return True
+        return False
+
+    @property
     def display_name_with_team(self):
         if self.internal_team:
             return '{} ({})'.format(self.display_name, self.internal_team)

--- a/lvfs/search/templates/search.html
+++ b/lvfs/search/templates/search.html
@@ -61,6 +61,15 @@
       Is not uploading firmware to the LVFS
     </li>
 {% endif %}
+{% if not vendor.is_unrestricted and vendor.restrictions %}
+    <li class="list-group-item">
+      <span class="fas fa-info-circle fs-2 text-info"></span>
+      Restricted to upload firmware for any hardware with vendor ID:
+{% for restriction in vendor.restrictions %}
+        <code>{{restriction.value}}</code>
+{% endfor %}
+    </li>
+{% endif %}
       </ul>
     </td>
   </tr>

--- a/lvfs/vendors/routes.py
+++ b/lvfs/vendors/routes.py
@@ -225,13 +225,17 @@ def route_show(vendor_id):
 
 @bp_vendors.route('/<int:vendor_id>/restrictions')
 @login_required
-@admin_login_required
 def route_restrictions(vendor_id):
     """ Allows changing a vendor [ADMIN ONLY] """
+
+    # security check
     vendor = db.session.query(Vendor).filter(Vendor.vendor_id == vendor_id).first()
     if not vendor:
-        flash('Failed to get vendor details: No a vendor with that group ID', 'warning')
-        return redirect(url_for('vendors.route_list_admin'), 302)
+        flash('Failed to get vendor details: No a vendor with that ID', 'warning')
+        return redirect(url_for('vendors.route_list'), 302)
+    if not vendor.check_acl('@view-restrictions'):
+        flash('Permission denied: Unable to view restrictions', 'danger')
+        return redirect(url_for('vendors.route_list'), 302)
     return render_template('vendor-restrictions.html',
                            category='vendors',
                            v=vendor)

--- a/lvfs/vendors/routes.py
+++ b/lvfs/vendors/routes.py
@@ -151,6 +151,21 @@ def route_list_admin():
                            vendors=vendors,
                            page='overview')
 
+@bp_vendors.route('/<int:vendor_id>')
+def route_show_public(vendor_id):
+    vendor = db.session.query(Vendor).\
+                filter(Vendor.visible).\
+                filter(Vendor.vendor_id == vendor_id).\
+                    options(joinedload(Vendor.users),
+                            joinedload(Vendor.affiliations)).first()
+    if not vendor:
+        flash('Failed to show vendor: No visible vendor with that group ID', 'warning')
+        return redirect(url_for('vendors.route_list'), 302)
+    return render_template('vendor-show.html',
+                           category='vendors',
+                           v=vendor,
+                           page='overview')
+
 @bp_vendors.route('/create', methods=['GET', 'POST'])
 @login_required
 @admin_login_required

--- a/lvfs/vendors/templates/vendor-nav.html
+++ b/lvfs/vendors/templates/vendor-nav.html
@@ -11,9 +11,11 @@
       <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'vendor_oauth' else 'default'}}"
         href="{{url_for('vendors.route_oauth', vendor_id=v.vendor_id)}}">OAuth</a>
 {% endif %}
-{% if g.user.check_acl('@admin') %}
+{% if v.check_acl('@view-restrictions') %}
       <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'vendor_restrictions' else 'default'}}"
         href="{{url_for('vendors.route_restrictions', vendor_id=v.vendor_id)}}">Restrictions</a>
+{% endif %}
+{% if g.user.check_acl('@admin') %}
       <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'vendor_namespaces' else 'default'}}"
         href="{{url_for('vendors.route_namespaces', vendor_id=v.vendor_id)}}">Namespaces</a>
 {% endif %}

--- a/lvfs/vendors/templates/vendor-restrictions.html
+++ b/lvfs/vendors/templates/vendor-restrictions.html
@@ -7,6 +7,11 @@
 <div class="alert alert-warning mt-1" role="alert">
   Due to the sensitive nature of providing firmware only vendors can install
   firmware on their own devices.
+{% if not g.user.check_acl('@admin') %}
+  Please contact the <a href="mailto:info@fwupd.org">LVFS administrator</a>
+  if you would like to add new <code>DMI:</code>, <code>PCI:0x</code> or
+  <code>USB:0x</code> vendor IDs to your account.
+{% endif %}
 </div>
 <div class="card mt-3">
   <div class="card-body">
@@ -37,9 +42,11 @@
 {% endif %}
     </td>
     <td class="col col-sm-2">
+{% if g.user.check_acl('@admin') %}
       <a class="btn btn-block btn-danger"
         href="{{url_for('vendors.route_restriction_delete', vendor_id=v.vendor_id, restriction_id=r.restriction_id)}}"
         role="button">Delete</a>
+{% endif %}
     </td>
   </tr>
 {% endfor %}
@@ -48,6 +55,7 @@
 </div>
 {% endif %}
 
+{% if g.user.check_acl('@admin') %}
 <form method="post" action="{{url_for('vendors.route_restriction_create', vendor_id=v.vendor_id)}}">
 <input type="hidden" name="csrf_token" value="{{csrf_token()}}"/>
 <div class="card mt-3">
@@ -63,5 +71,6 @@
   </div>
 </div>
 </form>
+{% endif %}
 
 {% endblock %}

--- a/lvfs/vendors/templates/vendor-restrictions.html
+++ b/lvfs/vendors/templates/vendor-restrictions.html
@@ -21,12 +21,21 @@
 {% else %}
 <table class="table">
   <tr class="row table-borderless">
-    <th class="col col-sm-10">Value</th>
+    <th class="col col-sm-5">Value</th>
+    <th class="col col-sm-5">Note</th>
     <th class="col col-sm-2">&nbsp;</th>
   </tr>
 {% for r in v.restrictions %}
   <tr class="row">
-    <td class="col col-sm-10"><code>{{r.value}}</code></td>
+    <td class="col col-sm-5"><code>{{r.value}}</code></td>
+    <td class="col col-sm-5">
+{% if r.value == '*' %}
+      <span class="fas fa-exclamation-triangle fs-1 text-warning"></span>
+      <strong>Vendor can update firmware on any device!</strong>
+{% else %}
+      &mdash;
+{% endif %}
+    </td>
     <td class="col col-sm-2">
       <a class="btn btn-block btn-danger"
         href="{{url_for('vendors.route_restriction_delete', vendor_id=v.vendor_id, restriction_id=r.restriction_id)}}"
@@ -46,6 +55,9 @@
     <div class="card-title">Add a new restriction</div>
     <p class="card-text">
       <input type="text" class="form-control" name="value" value="" placeholder="Restriction..." required>
+    </p>
+    <p class="card-text text-secondary">
+      Use <code>*</code> to unrestrict the vendor for all hardware.
     </p>
     <input type="submit" class="card-link btn btn-primary" value="Add">
   </div>

--- a/lvfs/vendors/templates/vendorlist-admin.html
+++ b/lvfs/vendors/templates/vendorlist-admin.html
@@ -8,7 +8,7 @@
   <div class="card-body">
     <div class="card-title">Vendor accounts</div>
     <table class="table">
-      <tr class="row">
+      <tr class="row table-borderless">
         <th class="col-3">Group ID</th>
         <th class="col-5">Display Name</th>
         <th class="col-3">Attributes</th>
@@ -20,15 +20,35 @@
         <td class="col-5">{{v.display_name_with_team}}</td>
         <td class="col-3">
           <code>
-{% if not v.visible %}hidden{% endif %}
-{% if v.quote_text %}quoted{% endif %}
-{% if v.consulting_text %}consulting{% endif %}
-{% if v.oauth_domain_glob %}oauth{% endif %}
-{% if v.banned_country_codes %}embargoed{% endif %}
-{% if v.do_not_track %}do-not-track{% endif %}
-{% if v.restrictions %}restricted{% endif %}
-{% if v.visible_for_search %}search{% endif %}
-{% if v.visible_on_landing %}landing{% endif %}
+{% if not v.visible %}
+          <span class="fas fa-eye-slash fs-2 text-info" title="hidden"></span>
+{% endif %}
+{% if v.visible_for_search %}
+          <span class="fas fa-search fs-2 text-info" title="visible-for-search"></span>
+{% endif %}
+{% if v.consulting_text %}
+          <span class="fas fa-user-tie fs-2 text-info" title="consulting"></span>
+{% endif %}
+{% if v.oauth_domain_glob %}
+          <span class="fas fa-sign-in-alt fs-2 text-info" title="oauth"></span>
+{% endif %}
+{% if v.banned_country_codes %}
+          <span class="fas fa-globe-europe fs-2 text-warning" title="banned-country-codes"></span>
+{% endif %}
+{% if v.do_not_track %}
+          <span class="fas fa-user-secret fs-2 text-info" title="do-not-track"></span>
+{% endif %}
+{% if v.is_unrestricted %}
+          <span class="fas fa-lock-open fs-2 text-danger" title="unrestricted"></span>
+{% elif v.restrictions %}
+          <span class="fas fa-lock fs-2 text-success" title="restricted"></span>
+{% endif %}
+{% if v.visible_on_landing %}
+          <span class="fas fa-home fs-2 text-info" title="visible-on-landing"></span>
+{% endif %}
+{% if v.quote_text %}
+          <span class="fas fa-quote-right fs-2 text-info" title="quoted"></span>
+{% endif %}
           </code>
         </td>
         <td class="col-1">


### PR DESCRIPTION
At the moment I create vendor accounts for OEMs and ODMs for testing. I then
create them a first user account, and over time they add more accounts, upload
firmware, test with embargo on real hardware and then ask to be able to promote
to stable.

This default state means that the new user with the @trusted ACL can push
firmware for any vendors hardware as the vendor-id was never set. It's very easy
to forget to ask the vendor what ID to use as part of the onboarding process.

Move to a model where vendors are restricted by default, so that any missing
vendor-ids are caught during testing with embargo.
For OEMs like Dell and Lenovo make the 'unrestricted' vendor ID an explicit
step (with a vendor ID of '*') rather than just a side effect of never
assigning a vendor ID.

When deploying this change we need to remember to manually give the vendor-id
of `*` to all the vendors shipping UEFI capsule or coreboot firmware so that the
vendor ID is not set, as fwupd does not set a vendor-id in all versions.