### PR TITLE
Always use offset-naive DateTime objects for humanize

### DIFF
--- a/lvfs/main/routes.py
+++ b/lvfs/main/routes.py
@@ -162,7 +162,7 @@ def utility_processor():
     def format_humanize_naturaltime(tmp):
         if not tmp:
             return 'n/a'
-        return humanize.naturaltime(tmp)
+        return humanize.naturaltime(tmp.replace(tzinfo=None))
 
     def format_humanize_intchar(tmp):
         if tmp > 1000000:


### PR DESCRIPTION
The DateTime object from postgresql is offset-aware, which humanize can't do.