### PR TITLE
Use properties for the plugin name and summary

### DIFF
--- a/lvfs/components/templates/component-certificates.html
+++ b/lvfs/components/templates/component-certificates.html
@@ -45,7 +45,7 @@
 {% if cert.plugin_id %}
       <tr class="row">
         <th class="col-2">Plugin</th>
-        <td class="col">{{format_plugin_id(cert.plugin_id).name()}}</td>
+        <td class="col">{{format_plugin_id(cert.plugin_id).name}}</td>
       </tr>
 {% endif %}
     </table>

--- a/lvfs/components/templates/component-shards.html
+++ b/lvfs/components/templates/component-shards.html
@@ -23,7 +23,7 @@
 {% if shard.plugin_id %}
         <tr class="row">
           <th class="col-2">Plugin</th>
-          <td class="col">{{format_plugin_id(shard.plugin_id).name()}}</td>
+          <td class="col">{{format_plugin_id(shard.plugin_id).name}}</td>
         </tr>
 {% endif %}
 {% if shard.size %}

--- a/lvfs/firmware/templates/firmware-tests.html
+++ b/lvfs/firmware/templates/firmware-tests.html
@@ -20,12 +20,12 @@
 {% for test in fw.tests %}
 <div class="card mb-3">
   <div class="card-header card-title list-group-item-{{test.color}}">
-    {{format_plugin_id(test.plugin_id).name()}}
+    {{format_plugin_id(test.plugin_id).name}}
     <span class="float-right">{{format_humanize_naturaltime(test.timestamp)}}</span>
   </div>
   <div class="card-body">
     <p class="card-text">
-      {{format_plugin_id(test.plugin_id).summary()}}
+      {{format_plugin_id(test.plugin_id).summary}}
     </p>
 {% if test.waived_ts %}
     <p class="card-text">

--- a/lvfs/main/routes.py
+++ b/lvfs/main/routes.py
@@ -214,7 +214,7 @@ def utility_processor():
                 format_timestamp=format_timestamp,
                 format_iso3166=format_iso3166,
                 format_plugin_id=format_plugin_id,
-                loader_plugins=sorted(ploader.get_all(), key=lambda x: x.name()))
+                loader_plugins=sorted(ploader.get_all(), key=lambda x: x.name))
 
 @lm.unauthorized_handler
 def unauthorized():

--- a/lvfs/pluginloader.py
+++ b/lvfs/pluginloader.py
@@ -55,12 +55,8 @@ class PluginBase:
         self.id = plugin_id
         self.priority = 0
         self._setting_kvs = {}
-
-    def name(self):
-        return 'Noname Plugin'
-
-    def summary(self):
-        return 'Plugin did not set summary()'
+        self.name = 'Noname Plugin'
+        self.summary = 'Plugin did not set summary'
 
     def settings(self):
         return []
@@ -95,12 +91,8 @@ class PluginBase:
 class PluginGeneral(PluginBase):
     def __init__(self):
         PluginBase.__init__(self, 'general')
-
-    def name(self):
-        return 'General'
-
-    def summary(self):
-        return 'General server settings.'
+        self.name = 'General'
+        self.summary = 'General server settings'
 
     def settings(self):
         s = []

--- a/lvfs/settings/templates/settings.html
+++ b/lvfs/settings/templates/settings.html
@@ -8,8 +8,8 @@
   <div class="card-body">
   <form class="form" method="post" action="{{url_for('settings.route_modify', plugin_id=plugin.id)}}">
     <input type="hidden" name="csrf_token" value="{{csrf_token()}}"/>
-    <div class="card-title">{{plugin.name()}}</div>
-    <p class="card-text">{{plugin.summary()}}</p>
+    <div class="card-title">{{plugin.name}}</div>
+    <p class="card-text">{{plugin.summary}}</p>
 {% for s in plugin.settings() %}
     <div class="form-group">
 {% if s.__class__.__name__ == 'PluginSettingBool' %}

--- a/lvfs/templates/private.html
+++ b/lvfs/templates/private.html
@@ -166,7 +166,7 @@
           <ul class="nav collapse {{'show' if category == 'settings'}}" id="settings" data-parent="#navbarVerticalCollapse">
 {% for plugin in loader_plugins %}
             <li class="nav-item {{'active' if category == 'settings' and plugin_id == plugin.id}}">
-              <a class="nav-link" href="{{url_for('settings.route_view', plugin_id=plugin.id)}}">{{plugin.name()}}</a>
+              <a class="nav-link" href="{{url_for('settings.route_view', plugin_id=plugin.id)}}">{{plugin.name}}</a>
             </li>
 {% endfor %}
           </ul>

--- a/lvfs/tests/templates/test-list.html
+++ b/lvfs/tests/templates/test-list.html
@@ -16,12 +16,12 @@
 {% for test in tests %}
 <div class="card mb-3">
   <div class="card-header card-title list-group-item-{{test.color}}">
-    {{format_plugin_id(test.plugin_id).name()}}
+    {{format_plugin_id(test.plugin_id).name}}
     <span class="float-right">{{format_humanize_naturaltime(test.timestamp)}}</span>
   </div>
   <div class="card-body">
     <p class="card-text">
-      {{format_plugin_id(test.plugin_id).summary()}}
+      {{format_plugin_id(test.plugin_id).summary}}
     </p>
 {% if test.is_pending %}
     <p class="card-text">Test is pending…</p>

--- a/lvfs/tests/templates/test-overview.html
+++ b/lvfs/tests/templates/test-overview.html
@@ -6,8 +6,8 @@
 {% for plugin_id in plugin_ids %}
 <div class="card mt-3">
   <div class="card-body">
-    <div class="card-title">{{plugins[plugin_id].name()}}</div>
-<p class="text-secondary">{{plugins[plugin_id].summary()}}</p>
+    <div class="card-title">{{plugins[plugin_id].name}}</div>
+<p class="text-secondary">{{plugins[plugin_id].summary}}</p>
 <table class="table">
 {% if tests_pending[plugin_id]|length > 0 %}
   <tr class="row table-borderless">

--- a/plugins/amdpsp/__init__.py
+++ b/plugins/amdpsp/__init__.py
@@ -69,12 +69,8 @@ def _run_psptool_on_blob(self, test, md):
 class Plugin(PluginBase):
     def __init__(self, plugin_id=None):
         PluginBase.__init__(self, plugin_id)
-
-    def name(self):
-        return 'AMD PSP'
-
-    def summary(self):
-        return 'Analyse modules in AMD PSP firmware'
+        self.name = 'AMD PSP'
+        self.summary = 'Analyse modules in AMD PSP firmware'
 
     def settings(self):
         s = []

--- a/plugins/auth-azure/__init__.py
+++ b/plugins/auth-azure/__init__.py
@@ -37,12 +37,8 @@ if 'auth_azure_consumer_key' in settings and settings['auth_azure_consumer_key']
 class Plugin(PluginBase):
     def __init__(self):
         PluginBase.__init__(self)
-
-    def name(self):
-        return 'Azure AD'
-
-    def summary(self):
-        return 'Authenticate against Microsoft Azure Active Directory.'
+        self.name = 'Azure AD'
+        self.summary = 'Authenticate against Microsoft Azure Active Directory'
 
     def settings(self):
         s = []

--- a/plugins/blocklist/__init__.py
+++ b/plugins/blocklist/__init__.py
@@ -43,12 +43,8 @@ class Plugin(PluginBase):
     def __init__(self, plugin_id=None):
         PluginBase.__init__(self, plugin_id)
         self.rules = None
-
-    def name(self):
-        return 'Blocklist'
-
-    def summary(self):
-        return 'Use YARA to check firmware for problems'
+        self.name = 'Blocklist'
+        self.summary = 'Use YARA to check firmware for problems'
 
     def order_after(self):
         return ['chipsec', 'intelme']

--- a/plugins/cdn-purge/__init__.py
+++ b/plugins/cdn-purge/__init__.py
@@ -24,12 +24,8 @@ def _basename_matches_globs(basename, globs):
 class Plugin(PluginBase):
     def __init__(self):
         PluginBase.__init__(self)
-
-    def name(self):
-        return 'CDN Purge'
-
-    def summary(self):
-        return 'Manually purge files from a content delivery network.'
+        self.name = 'CDN Purge'
+        self.summary = 'Manually purge files from a content delivery network'
 
     def settings(self):
         s = []

--- a/plugins/chipsec/__init__.py
+++ b/plugins/chipsec/__init__.py
@@ -110,12 +110,8 @@ class PfsFile:
 class Plugin(PluginBase):
     def __init__(self, plugin_id=None):
         PluginBase.__init__(self, plugin_id)
-
-    def name(self):
-        return 'CHIPSEC'
-
-    def summary(self):
-        return 'Add firmware shards for UEFI capsules'
+        self.name = 'CHIPSEC'
+        self.summary = 'Add firmware shards for UEFI capsules'
 
     def settings(self):
         s = []

--- a/plugins/clamav/__init__.py
+++ b/plugins/clamav/__init__.py
@@ -17,12 +17,8 @@ from lvfs.models import Test
 class Plugin(PluginBase):
     def __init__(self):
         PluginBase.__init__(self)
-
-    def name(self):
-        return 'ClamAV'
-
-    def summary(self):
-        return 'Check the firmware for trojans, viruses, malware and other malicious threats'
+        self.name = 'ClamAV'
+        self.summary = 'Check the firmware for trojans, viruses, malware and other malicious threats'
 
     def settings(self):
         s = []

--- a/plugins/dfu/__init__.py
+++ b/plugins/dfu/__init__.py
@@ -16,12 +16,8 @@ from lvfs.models import Test
 class Plugin(PluginBase):
     def __init__(self):
         PluginBase.__init__(self)
-
-    def name(self):
-        return 'DFU'
-
-    def summary(self):
-        return 'Check the DFU firmware footer'
+        self.name = 'DFU'
+        self.summary = 'Check the DFU firmware footer'
 
     def settings(self):
         s = []

--- a/plugins/info-readme/__init__.py
+++ b/plugins/info-readme/__init__.py
@@ -13,12 +13,8 @@ from lvfs.pluginloader import PluginBase, PluginError, PluginSettingText, Plugin
 class Plugin(PluginBase):
     def __init__(self):
         PluginBase.__init__(self)
-
-    def name(self):
-        return 'Readme'
-
-    def summary(self):
-        return 'Add a README file to the archive.'
+        self.name = 'Readme'
+        self.summary = 'Add a README file to the archive'
 
     def settings(self):
         s = []

--- a/plugins/intelme/__init__.py
+++ b/plugins/intelme/__init__.py
@@ -161,12 +161,8 @@ def _run_intelme_on_blob(self, test, md):
 class Plugin(PluginBase):
     def __init__(self, plugin_id=None):
         PluginBase.__init__(self, plugin_id)
-
-    def name(self):
-        return 'Intel ME'
-
-    def summary(self):
-        return 'Analyse modules in Intel ME firmware'
+        self.name = 'Intel ME'
+        self.summary = 'Analyse modules in Intel ME firmware'
 
     def settings(self):
         s = []

--- a/plugins/pecheck/__init__.py
+++ b/plugins/pecheck/__init__.py
@@ -87,12 +87,8 @@ def _extract_certs_from_authenticode_blob(buf):
 class Plugin(PluginBase):
     def __init__(self, plugin_id=None):
         PluginBase.__init__(self, plugin_id)
-
-    def name(self):
-        return 'PE Check'
-
-    def summary(self):
-        return 'Check the portable executable file (.efi) for common problems'
+        self.name = 'PE Check'
+        self.summary = 'Check the portable executable file (.efi) for common problems'
 
     def order_after(self):
         return ['chipsec', 'intelme']

--- a/plugins/shard-claim/__init__.py
+++ b/plugins/shard-claim/__init__.py
@@ -15,12 +15,8 @@ class Plugin(PluginBase):
     def __init__(self, plugin_id=None):
         PluginBase.__init__(self, plugin_id)
         self.infos_by_guid = {}
-
-    def name(self):
-        return 'Shard Claim'
-
-    def summary(self):
-        return 'Add component claims based on shard GUIDs'
+        self.name = 'Shard Claim'
+        self.summary = 'Add component claims based on shard GUIDs'
 
     def order_after(self):
         return ['chipsec']

--- a/plugins/sign-gpg/__init__.py
+++ b/plugins/sign-gpg/__init__.py
@@ -64,12 +64,8 @@ class Affidavit:
 class Plugin(PluginBase):
     def __init__(self):
         PluginBase.__init__(self)
-
-    def name(self):
-        return 'GPG Signing'
-
-    def summary(self):
-        return 'Sign files using GnuPG, a free implementation of the OpenPGP standard.'
+        self.name = 'GPG Signing'
+        self.summary = 'Sign files using GnuPG, a free implementation of the OpenPGP standard'
 
     def settings(self):
         s = []

--- a/plugins/sign-pkcs7/__init__.py
+++ b/plugins/sign-pkcs7/__init__.py
@@ -17,12 +17,8 @@ from lvfs import ploader, app
 class Plugin(PluginBase):
     def __init__(self):
         PluginBase.__init__(self)
-
-    def name(self):
-        return 'PKCS#7 Signing'
-
-    def summary(self):
-        return 'Sign files using the GnuTLS public key infrastructure.'
+        self.name = 'PKCS#7 Signing'
+        self.summary = 'Sign files using the GnuTLS public key infrastructure'
 
     def settings(self):
         s = []

--- a/plugins/sign-sigul/__init__.py
+++ b/plugins/sign-sigul/__init__.py
@@ -51,12 +51,8 @@ def _sigul_detached_sign_data(contents, config, key):
 class Plugin(PluginBase):
     def __init__(self):
         PluginBase.__init__(self)
-
-    def name(self):
-        return 'Sigul Signing'
-
-    def summary(self):
-        return 'GPG sign files using Sigul, a secure signing server.'
+        self.name = 'Sigul Signing'
+        self.summary = 'GPG sign files using Sigul, a secure signing server'
 
     def settings(self):
         s = []

--- a/plugins/uefi-capsule/__init__.py
+++ b/plugins/uefi-capsule/__init__.py
@@ -16,12 +16,8 @@ from lvfs.models import Test
 class Plugin(PluginBase):
     def __init__(self):
         PluginBase.__init__(self)
-
-    def name(self):
-        return 'UEFI Capsule'
-
-    def summary(self):
-        return 'Check the UEFI capsule header and file structure'
+        self.name = 'UEFI Capsule'
+        self.summary = 'Check the UEFI capsule header and file structure'
 
     def settings(self):
         s = []

--- a/plugins/virustotal/__init__.py
+++ b/plugins/virustotal/__init__.py
@@ -16,12 +16,8 @@ from lvfs.models import Test
 class Plugin(PluginBase):
     def __init__(self):
         PluginBase.__init__(self)
-
-    def name(self):
-        return 'VirusTotal Monitor'
-
-    def summary(self):
-        return 'Upload firmware to VirusTotal for false-positive detection'
+        self.name = 'VirusTotal Monitor'
+        self.summary = 'Upload firmware to VirusTotal for false-positive detection'
 
     def settings(self):
         s = []

--- a/plugins/wu-copy/__init__.py
+++ b/plugins/wu-copy/__init__.py
@@ -12,12 +12,8 @@ from lvfs.pluginloader import PluginBase, PluginSettingBool
 class Plugin(PluginBase):
     def __init__(self):
         PluginBase.__init__(self)
-
-    def name(self):
-        return 'Windows Update'
-
-    def summary(self):
-        return 'Copy files generated using Windows Update.'
+        self.name = 'Windows Update'
+        self.summary = 'Copy files generated using Windows Update'
 
     def settings(self):
         s = []


### PR DESCRIPTION
No plugins have to do anything non-static, and ninja doesn't mind if you try to
print a property that does not exist, but explodes if you try calling None.