### PR TITLE
Allow adding component claims based on the hash of a shard

### DIFF
--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -1296,6 +1296,24 @@ def _calculate_entropy(s):
     e_x = [- p_x * math.log(p_x, 2) for p_x in probabilities]
     return sum(e_x)
 
+class ComponentShardClaim(db.Model):
+
+    # sqlalchemy metadata
+    __tablename__ = 'component_shard_claims'
+    __table_args__ = {'mysql_character_set': 'utf8mb4'}
+
+    component_shard_claim_id = Column(Integer, primary_key=True)
+    component_shard_info_id = Column(Integer, ForeignKey('component_shard_infos.component_shard_info_id'))
+    checksum = Column(Text, nullable=False, default=None)
+    kind = Column(Text, default=None)                   # enum type
+    value = Column(Text, default=None)                  # summary
+
+    info = relationship('ComponentShardInfo')
+
+    def __repr__(self):
+        return "ComponentShardClaim object {},{} -> {}({})"\
+                    .format(self.info.guid, self.checksum, self.kind, self.value)
+
 class ComponentShard(db.Model):
 
     # sqlalchemy metadata
@@ -1625,6 +1643,13 @@ class Component(db.Model):
                 name += ' ' + self.category.name
             else:
                 name += ' ' + self.category.value
+        return name
+
+    @property
+    def name_with_vendor(self):
+        name = self.fw.vendor.display_name + ' ' + self.name
+        if self.name_variant_suffix:
+            name += ' (' + self.name_variant_suffix + ')'
         return name
 
     @property

--- a/lvfs/shards/routes.py
+++ b/lvfs/shards/routes.py
@@ -5,12 +5,14 @@
 #
 # SPDX-License-Identifier: GPL-2.0+
 
+from collections import defaultdict
+
 from flask import Blueprint, request, url_for, redirect, flash, render_template, make_response
 from flask_login import login_required
 
 from lvfs import db
 
-from lvfs.models import ComponentShard, ComponentShardInfo
+from lvfs.models import ComponentShard, ComponentShardInfo, Component, ComponentShardClaim
 from lvfs.util import admin_login_required
 
 bp_shards = Blueprint('shards', __name__, template_folder='templates')
@@ -64,6 +66,138 @@ def route_show(component_shard_info_id):
     return render_template('shard-details.html',
                            category='admin',
                            shard=shard)
+
+@bp_shards.route('/<int:component_shard_info_id>/components')
+@login_required
+@admin_login_required
+def route_components(component_shard_info_id):
+
+    # find shard
+    shard_info = db.session.query(ComponentShardInfo).\
+            filter(ComponentShardInfo.component_shard_info_id == component_shard_info_id).first()
+    if not shard_info:
+        flash('No shard found', 'info')
+        return redirect(url_for('shards.route_list'))
+
+    # get shards with a unique component appstream ID
+    shards = db.session.query(ComponentShard)\
+                       .join(ComponentShardInfo)\
+                       .filter(ComponentShardInfo.component_shard_info_id == component_shard_info_id)\
+                       .join(Component)\
+                       .distinct(Component.appstream_id)\
+                       .order_by(Component.appstream_id, ComponentShard.name.desc())\
+                       .all()
+    unique_mds = defaultdict(list)
+    for shard in shards:
+        if shard.md not in unique_mds[shard.name]:
+            unique_mds[shard.name].append(shard.md)
+
+    # show details
+    return render_template('shard-components.html',
+                           category='admin',
+                           unique_mds=unique_mds,
+                           shard=shard_info)
+
+@bp_shards.route('/<int:component_shard_info_id>/checksums')
+@login_required
+@admin_login_required
+def route_checksums(component_shard_info_id):
+
+    # find shard
+    shard_info = db.session.query(ComponentShardInfo).\
+            filter(ComponentShardInfo.component_shard_info_id == component_shard_info_id).first()
+    if not shard_info:
+        flash('No shard found', 'info')
+        return redirect(url_for('shards.route_list'))
+
+    # get shards with a unique component appstream ID
+    shards = db.session.query(ComponentShard)\
+                       .join(ComponentShardInfo)\
+                       .filter(ComponentShardInfo.component_shard_info_id == component_shard_info_id)\
+                       .all()
+    unique_mds = defaultdict(list)
+    for shard in shards:
+        if shard.md not in unique_mds[shard.checksum]:
+            unique_mds[shard.checksum].append(shard.md)
+
+    # show details
+    return render_template('shard-checksums.html',
+                           category='admin',
+                           unique_mds=unique_mds,
+                           shard=shard_info)
+
+@bp_shards.route('/<int:component_shard_info_id>/claims')
+@login_required
+@admin_login_required
+def route_claims(component_shard_info_id):
+
+    # find shard
+    shard = db.session.query(ComponentShardInfo).\
+            filter(ComponentShardInfo.component_shard_info_id == component_shard_info_id).first()
+    if not shard:
+        flash('No shard found', 'info')
+        return redirect(url_for('shards.route_list'))
+
+    # get shards with a unique component appstream ID
+    claims = db.session.query(ComponentShardClaim)\
+                       .filter(ComponentShardClaim.component_shard_info_id == component_shard_info_id)\
+                       .all()
+
+    # show details
+    return render_template('shard-claims.html',
+                           category='admin',
+                           claims=claims,
+                           shard=shard)
+
+@bp_shards.route('/<int:component_shard_info_id>/claim/<int:component_shard_claim_id>/delete')
+@login_required
+@admin_login_required
+def route_shard_claim_delete(component_shard_info_id, component_shard_claim_id):
+
+    # find shard
+    shard_claim = db.session.query(ComponentShardClaim)\
+                            .filter(ComponentShardClaim.component_shard_info_id == component_shard_info_id)\
+                            .filter(ComponentShardClaim.component_shard_claim_id == component_shard_claim_id)\
+                            .first()
+    if not shard_claim:
+        flash('No shard claim found', 'info')
+        return redirect(url_for('shards.route_list'))
+    db.session.delete(shard_claim)
+    db.session.commit()
+    flash('Deleted shard claim', 'info')
+    return redirect(url_for('shards.route_claims',
+                            component_shard_info_id=component_shard_info_id))
+
+@bp_shards.route('/<int:component_shard_info_id>/claim/create', methods=['POST'])
+@login_required
+@admin_login_required
+def route_shard_claim_create(component_shard_info_id):
+
+    # ensure has enough data
+    for key in ['checksum', 'kind', 'value']:
+        if key not in request.form:
+            flash('No {} form data found!'.format(key), 'warning')
+            return redirect(url_for('shards.route_list'))
+
+    # already exists
+    if db.session.query(ComponentShardClaim)\
+                 .filter(ComponentShardClaim.component_shard_info_id == component_shard_info_id)\
+                 .filter(ComponentShardClaim.checksum == request.form['checksum'])\
+                 .first():
+        flash('Failed to add component shard claim: The checksum already exists', 'info')
+        return redirect(url_for('issues.route_list'))
+
+    # add issue
+    claim = ComponentShardClaim(component_shard_info_id=component_shard_info_id,
+                                checksum=request.form['checksum'],
+                                kind=request.form['kind'],
+                                value=request.form['value'])
+    db.session.add(claim)
+    db.session.commit()
+    flash('Added claim', 'info')
+    return redirect(url_for('shards.route_claims',
+                            component_shard_info_id=component_shard_info_id))
+
 
 @bp_shards.route('/<int:component_shard_id>/download')
 @login_required

--- a/lvfs/shards/routes_test.py
+++ b/lvfs/shards/routes_test.py
@@ -24,23 +24,23 @@ class LocalTestCase(LvfsTestCase):
         rv = self.app.get('/lvfs/firmware/1/tests')
 
         # UEFI Capsule
-        assert 'HeaderSize: 0x1c' in rv.data.decode('utf-8'), rv.data
-        assert 'GUID: cc4cbfa9-bf9d-540b-b92b-172ce31013c1' in rv.data.decode('utf-8'), rv.data
+        assert 'HeaderSize: 0x1c' in rv.data.decode(), rv.data
+        assert 'GUID: cc4cbfa9-bf9d-540b-b92b-172ce31013c1' in rv.data.decode(), rv.data
 
         # does not always exist
         if not os.path.exists('/usr/bin/chipsec_util'):
             return
 
         # CHIPSEC -> Blocklist
-        assert 'Found PFS in Zlib compressed blob' in rv.data.decode('utf-8'), rv.data.decode()
-        assert 'IbvExampleCertificate' in rv.data.decode('utf-8'), rv.data.decode()
+        assert 'Found PFS in Zlib compressed blob' in rv.data.decode(), rv.data.decode()
+        assert 'IbvExampleCertificate' in rv.data.decode(), rv.data.decode()
 
         # run the cron job to create the ComponentShardInfo's
         self.run_cron_stats()
 
         # edit a shard description
         rv = self.app.get('/lvfs/shards/')
-        assert '12345678-1234-5678-1234-567812345678' in rv.data.decode('utf-8'), rv.data.decode()
+        assert '12345678-1234-5678-1234-567812345678' in rv.data.decode(), rv.data.decode()
         rv = self.app.get('/lvfs/shards/1/details')
         rv = self.app.post('/lvfs/shards/1/modify', data=dict(
             description='Hello Dave',
@@ -50,7 +50,56 @@ class LocalTestCase(LvfsTestCase):
 
         # view component certificates
         rv = self.app.get('/lvfs/components/1/certificates')
-        assert 'Default Company Ltd' in rv.data.decode('utf-8'), rv.data
+        assert 'Default Company Ltd' in rv.data.decode(), rv.data
+
+        # view components
+        rv = self.app.get('/lvfs/shards/1/components')
+        assert 'com.dell.12345678-1234-5678-1234-567812345678' in rv.data.decode(), rv.data.decode()
+        assert 'UEFI' in rv.data.decode(), rv.data.decode()
+
+        # view checksums
+        rv = self.app.get('/lvfs/shards/1/checksums')
+        assert '15acb2018caa6a136ec26d629377098e6690132577e26712da59f150ca28b436' in rv.data.decode(), rv.data.decode()
+        assert 'UEFI' in rv.data.decode(), rv.data.decode()
+        assert '1.2.3' in rv.data.decode(), rv.data.decode()
+
+        # view claims
+        rv = self.app.get('/lvfs/shards/1/claims')
+        assert 'No claims exist yet' in rv.data.decode(), rv.data.decode()
+
+        # add claim
+        rv = self.app.post('/lvfs/shards/1/claim/create', data=dict(
+            checksum='DEADBEEF',
+            kind='info-dave',
+            value='Dave',
+        ), follow_redirects=True)
+        assert b'Added claim' in rv.data, rv.data.decode()
+
+        # add claim again
+        rv = self.app.post('/lvfs/shards/1/claim/create', data=dict(
+            checksum='DEADBEEF',
+            kind='info-bar',
+            value='Baz',
+        ), follow_redirects=True)
+        assert b'checksum already exists' in rv.data, rv.data.decode()
+
+        # verify it exists
+        rv = self.app.get('/lvfs/shards/1/claims')
+        assert 'DEADBEEF' in rv.data.decode(), rv.data.decode()
+        assert 'info-dave' in rv.data.decode(), rv.data.decode()
+        assert 'Dave' in rv.data.decode(), rv.data.decode()
+
+        # delete it
+        rv = self.app.get('/lvfs/shards/1/claim/1/delete', follow_redirects=True)
+        assert 'No claims exist yet' in rv.data.decode(), rv.data.decode()
+
+        # delete it again
+        rv = self.app.get('/lvfs/shards/1/claim/1/delete', follow_redirects=True)
+        assert 'No shard claim found' in rv.data.decode(), rv.data.decode()
+
+        # view claims
+        rv = self.app.get('/lvfs/shards/1/claims')
+        assert 'No claims exist yet' in rv.data.decode(), rv.data.decode()
 
 if __name__ == '__main__':
     unittest.main()

--- a/lvfs/shards/templates/shard-checksums.html
+++ b/lvfs/shards/templates/shard-checksums.html
@@ -1,0 +1,21 @@
+{% extends "default.html" %}
+{% block title %}Component Shard Checksums{% endblock %}
+
+{% block nav %}{% include 'shard-nav.html' %}{% endblock %}
+
+{% block content %}
+
+{% for appstream_id in unique_mds %}
+<div class="card mt-3">
+  <div class="card-body">
+    <div class="card-title"><code>{{appstream_id}}</code></div>
+    <ul class="list-group">
+{% for md in unique_mds[appstream_id]|sort(attribute='name_with_vendor') %}
+      <li class="list-group-item">{{md.name_with_vendor}} &mdash; {{md.version_display}}</code></li>
+{% endfor %}
+    </ul>
+  </div>
+</div>
+{% endfor %}
+
+{% endblock %}

--- a/lvfs/shards/templates/shard-claims.html
+++ b/lvfs/shards/templates/shard-claims.html
@@ -1,0 +1,61 @@
+{% extends "default.html" %}
+{% block title %}Component Shard Claims{% endblock %}
+
+{% block nav %}{% include 'shard-nav.html' %}{% endblock %}
+
+{% block content %}
+
+<div class="card">
+  <div class="card-body">
+    <div class="card-title">Component Shard Claims</div>
+<table class="table">
+  <tr class="row">
+    <th class="col col-sm-3">Checksum</th>
+    <th class="col col-sm-2">Compare</th>
+    <th class="col col-sm-5">Value</th>
+    <th class="col col-sm-2">&nbsp;</th>
+  </tr>
+{% if claims|length == 0 %}
+  <tr class="row">
+    <td class="col col-sm-12"><p class="text-muted">No claims exist yet.</p></td>
+  </tr>
+</p>
+{% else %}
+{% for claim in claims|sort(attribute='checksum') %}
+  <tr class="row">
+    <td class="col col-sm-3"><code>{{claim.checksum|truncate(32, False, '…')}}</code></td>
+    <td class="col col-sm-2"><code>{{claim.kind}}</code></td>
+    <td class="col col-sm-5">{{claim.value|truncate(50, False, '…')}}</td>
+    <td class="col col-sm-2">
+      <a class="btn btn-block btn-danger"
+        href="{{url_for('shards.route_shard_claim_delete',
+                        component_shard_info_id=claim.component_shard_info_id,
+                        component_shard_claim_id=claim.component_shard_claim_id)}}"
+        role="button">Delete</a>
+    </td>
+  </tr>
+{% endfor %}
+{% endif %}
+  <tr class="row">
+    <form method="post" action="{{url_for('shards.route_shard_claim_create',
+                                          component_shard_info_id=shard.component_shard_info_id)}}">
+    <input type="hidden" name="csrf_token" value="{{csrf_token()}}"/>
+    <td class="col col-sm-3">
+      <input type="text" class="form-control" name="checksum" value="" placeholder="Checksum..." required>
+    </td>
+    <td class="col col-sm-2">
+      <input type="text" class="form-control" name="kind" value="" placeholder="Key..." required>
+    </td>
+    <td class="col col-sm-5">
+      <input type="text" class="form-control" name="value" value="" placeholder="Value..." required>
+    </td>
+    <td class="col col-sm-2">
+      <input type="submit" class="btn btn-block btn-primary" value="Add">
+    </td>
+    </form>
+  </tr>
+</table>
+  </div>
+</div>
+
+{% endblock %}

--- a/lvfs/shards/templates/shard-components.html
+++ b/lvfs/shards/templates/shard-components.html
@@ -1,0 +1,21 @@
+{% extends "default.html" %}
+{% block title %}Component Shard Components{% endblock %}
+
+{% block nav %}{% include 'shard-nav.html' %}{% endblock %}
+
+{% block content %}
+
+{% for appstream_id in unique_mds %}
+<div class="card mt-3">
+  <div class="card-body">
+    <div class="card-title"><code>{{appstream_id}}</code></div>
+    <ul class="list-group">
+{% for md in unique_mds[appstream_id]|sort(attribute='name_with_vendor') %}
+      <li class="list-group-item">{{md.name_with_vendor}}</code></li>
+{% endfor %}
+    </ul>
+  </div>
+</div>
+{% endfor %}
+
+{% endblock %}

--- a/lvfs/shards/templates/shard-details.html
+++ b/lvfs/shards/templates/shard-details.html
@@ -1,6 +1,8 @@
 {% extends "default.html" %}
 {% block title %}Component Shard Details{% endblock %}
 
+{% block nav %}{% include 'shard-nav.html' %}{% endblock %}
+
 {% block content %}
 <div class="card">
   <div class="card-body">
@@ -12,26 +14,15 @@
     <textarea type="text" class="form-control" name="description" rows="10">{{shard.description if shard.description}}</textarea>
   </div>
   <div class="form-group">
-    <label for="display_name">Claim Kind:</label>
+    <label for="display_name">GUID Claim Kind:</label>
     <input class="form-control" id="claim_kind" type="text" name="claim_kind" value="{{shard.claim_kind if shard.claim_kind}}">
   </div>
   <div class="form-group">
-    <label for="display_name">Claim Description:</label>
+    <label for="display_name">GUID Claim Description:</label>
     <input class="form-control" id="claim_value" type="text" name="claim_value" value="{{shard.claim_value if shard.claim_value}}">
   </div>
   <input type="submit" class="btn btn-primary btn-large" value="Modify">
 </form>
-  </div>
-</div>
-
-<div class="card mt-3">
-  <div class="card-body">
-    <div class="card-title">Shards</div>
-    <ul class="list-group">
-{% for shd in shard.shards %}
-      <li class="list-group-item">{{shd.md.fw.vendor.display_name}} {{shd.md.name}} &mdash; <code>{{shd.name}}</code></li>
-{% endfor %}
-    </ul>
   </div>
 </div>
 

--- a/lvfs/shards/templates/shard-nav.html
+++ b/lvfs/shards/templates/shard-nav.html
@@ -1,0 +1,14 @@
+<nav>
+  <div class="text-center mb-3">
+    <div class="btn-group" role="group">
+      <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'shards.route_show' else 'default'}}"
+        href="{{url_for('shards.route_show', component_shard_info_id=shard.component_shard_info_id)}}">Details</a>
+      <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'shards.route_components' else 'default'}}"
+        href="{{url_for('shards.route_components', component_shard_info_id=shard.component_shard_info_id)}}">Components</a>
+      <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'shards.route_checksums' else 'default'}}"
+        href="{{url_for('shards.route_checksums', component_shard_info_id=shard.component_shard_info_id)}}">Variants</a>
+      <a class="btn btn-falcon-{{'primary' if request.url_rule.endpoint == 'shards.route_claims' else 'default'}}"
+        href="{{url_for('shards.route_claims', component_shard_info_id=shard.component_shard_info_id)}}">Checksum Claims</a>
+    </div>
+  </div>
+</nav>

--- a/migrations/versions/58a8c79cd632_component_shard_claims.py
+++ b/migrations/versions/58a8c79cd632_component_shard_claims.py
@@ -1,0 +1,29 @@
+"""
+
+Revision ID: 58a8c79cd632
+Revises: e1b495a29979
+Create Date: 2020-01-24 12:02:34.098059
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '58a8c79cd632'
+down_revision = 'e1b495a29979'
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+    op.create_table('component_shard_claims',
+    sa.Column('component_shard_claim_id', sa.Integer(), nullable=False),
+    sa.Column('component_shard_info_id', sa.Integer(), nullable=True),
+    sa.Column('checksum', sa.Text(), nullable=False),
+    sa.Column('kind', sa.Text(), nullable=True),
+    sa.Column('value', sa.Text(), nullable=True),
+    sa.ForeignKeyConstraint(['component_shard_info_id'], ['component_shard_infos.component_shard_info_id'], ),
+    sa.PrimaryKeyConstraint('component_shard_claim_id'),
+    mysql_character_set='utf8mb4'
+    )
+
+def downgrade():
+    op.drop_table('component_shard_claims')


### PR DESCRIPTION
This allows us to add negative security claims to components that contain shards
with known security problems, for instance older versions of UsbRt.