### PR TITLE
Add Claim as a top level object

### DIFF
--- a/contrib/pylintrc
+++ b/contrib/pylintrc
@@ -7,7 +7,7 @@ unsafe-load-any-extension=yes
 [MESSAGES CONTROL]
 
 # Disable the message, report, category or checker with the given id(s)
-disable=invalid-name,len-as-condition,missing-docstring,too-many-return-statements,too-many-branches,import-outside-toplevel
+disable=invalid-name,len-as-condition,missing-docstring,too-many-return-statements,too-many-branches,import-outside-toplevel,too-many-public-methods
 
 [REPORTS]
 

--- a/lvfs/__init__.py
+++ b/lvfs/__init__.py
@@ -53,6 +53,7 @@ ploader = Pluginloader('plugins')
 from lvfs.agreements.routes import bp_agreements
 from lvfs.analytics.routes import bp_analytics
 from lvfs.categories.routes import bp_categories
+from lvfs.claims.routes import bp_claims
 from lvfs.components.routes import bp_components
 from lvfs.devices.routes import bp_devices
 from lvfs.mdsync.routes import bp_mdsync
@@ -77,6 +78,7 @@ from lvfs.verfmts.routes import bp_verfmts
 app.register_blueprint(bp_agreements, url_prefix='/lvfs/agreements')
 app.register_blueprint(bp_analytics, url_prefix='/lvfs/analytics')
 app.register_blueprint(bp_categories, url_prefix='/lvfs/categories')
+app.register_blueprint(bp_claims, url_prefix='/lvfs/claims')
 app.register_blueprint(bp_components, url_prefix='/lvfs/components')
 app.register_blueprint(bp_devices, url_prefix='/lvfs/devices')
 app.register_blueprint(bp_mdsync, url_prefix='/lvfs/mdsync')

--- a/lvfs/claims/routes.py
+++ b/lvfs/claims/routes.py
@@ -1,0 +1,109 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 Richard Hughes <richard@hughsie.com>
+#
+# SPDX-License-Identifier: GPL-2.0+
+
+from flask import Blueprint, request, url_for, redirect, flash, render_template
+from flask_login import login_required
+
+from lvfs import db
+
+from lvfs.models import Claim
+from lvfs.util import _error_internal
+from lvfs.util import admin_login_required
+
+bp_claims = Blueprint('claims', __name__, template_folder='templates')
+
+@bp_claims.route('/')
+@login_required
+@admin_login_required
+def route_list():
+
+    # only show claims with the correct group_id
+    claims = db.session.query(Claim).order_by(Claim.kind.asc()).all()
+    return render_template('claim-list.html',
+                           category='admin',
+                           claims=claims)
+
+@bp_claims.route('/create', methods=['POST'])
+@login_required
+@admin_login_required
+def route_create():
+
+    # ensure has enough data
+    if 'kind' not in request.form:
+        return _error_internal('No form data found!')
+    kind = request.form['kind']
+    if not kind or not kind.islower() or kind.find(' ') != -1:
+        flash('Failed to add claim: Value needs to be a lower case word', 'warning')
+        return redirect(url_for('claims.route_list'))
+
+    # already exists
+    if db.session.query(Claim).filter(Claim.kind == kind).first():
+        flash('Failed to add claim: The claim already exists', 'info')
+        return redirect(url_for('claims.route_list'))
+
+    # add claim
+    claim = Claim(kind=kind, summary=request.form.get('summary'))
+    db.session.add(claim)
+    db.session.commit()
+    flash('Added claim', 'info')
+    return redirect(url_for('claims.route_show', claim_id=claim.claim_id))
+
+@bp_claims.route('/<int:claim_id>/delete')
+@login_required
+@admin_login_required
+def route_delete(claim_id):
+
+    # get claim
+    claim = db.session.query(Claim).\
+            filter(Claim.claim_id == claim_id).first()
+    if not claim:
+        flash('No claim found', 'info')
+        return redirect(url_for('claims.route_list'))
+
+    # delete
+    db.session.delete(claim)
+    db.session.commit()
+    flash('Deleted claim', 'info')
+    return redirect(url_for('claims.route_list'))
+
+@bp_claims.route('/<int:claim_id>/modify', methods=['POST'])
+@login_required
+@admin_login_required
+def route_modify(claim_id):
+
+    # find claim
+    claim = db.session.query(Claim).\
+                filter(Claim.claim_id == claim_id).first()
+    if not claim:
+        flash('No claim found', 'info')
+        return redirect(url_for('claims.route_list'))
+
+    # modify claim
+    for key in ['kind', 'icon', 'summary', 'url']:
+        if key in request.form:
+            setattr(claim, key, request.form[key])
+    db.session.commit()
+
+    # success
+    flash('Modified claim', 'info')
+    return redirect(url_for('claims.route_show', claim_id=claim_id))
+
+@bp_claims.route('/<int:claim_id>/details')
+@login_required
+@admin_login_required
+def route_show(claim_id):
+
+    # find claim
+    claim = db.session.query(Claim).\
+            filter(Claim.claim_id == claim_id).first()
+    if not claim:
+        flash('No claim found', 'info')
+        return redirect(url_for('claims.route_list'))
+
+    # show details
+    return render_template('claim-details.html',
+                           claim=claim)

--- a/lvfs/claims/routes_test.py
+++ b/lvfs/claims/routes_test.py
@@ -1,0 +1,54 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 Richard Hughes <richard@hughsie.com>
+#
+# SPDX-License-Identifier: GPL-2.0+
+#
+# pylint: disable=wrong-import-position,singleton-comparison
+
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath('.'))
+
+from lvfs.testcase import LvfsTestCase
+
+class LocalTestCase(LvfsTestCase):
+
+    def test_claim(self):
+
+        self.login()
+        self.upload()
+        rv = self.app.get('/lvfs/claims/')
+        assert 'biosguard' not in rv.data.decode('utf-8'), rv.data
+
+        # create
+        rv = self.app.post('/lvfs/claims/create', data=dict(
+            kind='biosguard',
+        ), follow_redirects=True)
+        assert b'Added claim' in rv.data, rv.data.decode()
+        rv = self.app.get('/lvfs/claims/')
+        assert 'biosguard' in rv.data.decode('utf-8'), rv.data.decode()
+        rv = self.app.post('/lvfs/claims/create', data=dict(
+            kind='biosguard',
+        ), follow_redirects=True)
+        assert b'already exists' in rv.data, rv.data.decode()
+
+        # modify
+        rv = self.app.post('/lvfs/claims/1/modify', data=dict(
+            summary='BIOSGuard',
+        ), follow_redirects=True)
+        assert b'Modified claim' in rv.data, rv.data.decode()
+        rv = self.app.get('/lvfs/claims/')
+        assert 'BIOSGuard' in rv.data.decode('utf-8'), rv.data.decode()
+
+        # delete
+        rv = self.app.get('/lvfs/claims/1/delete', follow_redirects=True)
+        assert b'Deleted claim' in rv.data, rv.data.decode()
+        rv = self.app.get('/lvfs/claims/')
+        assert 'biosguard' not in rv.data.decode('utf-8'), rv.data.decode()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lvfs/claims/templates/claim-details.html
+++ b/lvfs/claims/templates/claim-details.html
@@ -1,0 +1,65 @@
+{% extends "default.html" %}
+{% block title %}Claim Details{% endblock %}
+
+{% block content %}
+
+<nav class="row">
+  <div class="col col-sm-1 btn-group mb-3">
+    <a class="btn btn-falcon-default mr-sm-3"
+      href="{{url_for('claims.route_list')}}">
+      <span class="fas fa-arrow-left"></span>
+    </a>
+  </div>
+</nav>
+
+<div class="card">
+  <div class="card-body">
+    <div class="card-title">Claim Details</div>
+<form method="post" action="{{url_for('claims.route_modify', claim_id=claim.claim_id)}}">
+  <input type="hidden" name="csrf_token" value="{{csrf_token()}}"/>
+  <div class="form-group">
+    <label for="group_id">Kind:</label>
+    <input type="text" class="form-control" name="kind" value="{{claim.kind}}" required />
+  </div>
+  <div class="form-group">
+    <label for="group_id">Icon:</label>
+    <input type="text" class="form-control" name="icon" value="{{claim.icon if claim.icon}}" required />
+  </div>
+  <div class="form-group">
+    <label for="display_name">Summary:</label>
+    <input type="text" class="form-control" name="summary" value="{{claim.summary if claim.summary}}" required />
+  </div>
+  <div class="form-group">
+    <label for="display_name">URL:</label>
+    <input type="text" class="form-control" name="url" value="{{claim.url if claim.url}}" required />
+  </div>
+  <input type="submit" class="card-link btn btn-primary" value="Modify">
+  <button type="button" class="card-link btn btn-danger" data-toggle="modal" data-target="#deleteModal">Delete</button>
+</form>
+  </div>
+</div>
+
+<!-- modal dialog -->
+<div class="modal" id="deleteModal" tabindex="-1" role="dialog" aria-labelledby="deleteModalLabel" aria-hidden="true">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="deleteModalLabel">Really Delete Claim?</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        Once deleted, claims can not be recovered.
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+        <a class="btn btn-danger"
+          href="{{url_for('claims.route_delete', claim_id=claim.claim_id)}}"
+          role="button">Delete</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+{% endblock %}

--- a/lvfs/claims/templates/claim-list.html
+++ b/lvfs/claims/templates/claim-list.html
@@ -1,0 +1,46 @@
+{% extends "default.html" %}
+{% block title %}Claims{% endblock %}
+
+{% block content %}
+
+<form method="post" action="{{url_for('claims.route_create')}}" class="form">
+<input type="hidden" name="csrf_token" value="{{csrf_token()}}"/>
+<div class="card mt-3">
+  <div class="card-body">
+    <div class="card-title">Claims</div>
+<table class="table">
+  <tr class="row table-borderless">
+    <th class="col col-sm-2">Kind</th>
+    <th class="col col-sm-8">Summary</th>
+    <th class="col col-sm-2">&nbsp;</th>
+  </tr>
+{% if claims|length == 0 %}
+  <tr class="row">
+    <th class="col col-sm-12 text-muted">No claims have been created</th>
+  </tr>
+{% endif %}
+{% for claim in claims %}
+  <tr class="row">
+    <td class="col col-sm-2"><code>{{claim.kind}}</code></td>
+    <td class="col col-sm-8">{{claim.summary}}</td>
+    <td class="col col-sm-2">
+      <a class="btn btn-info btn-block"
+         href="{{url_for('claims.route_show', claim_id=claim.claim_id)}}"
+         role="button">Details</a>
+    </td>
+  </tr>
+{% endfor %}
+  <tr class="row">
+    <td class="col col-sm-10">
+      <input class="form-control" type="text" name="kind" placeholder="kind" required>
+    </td>
+    <td class="col col-sm-2">
+      <input class="btn btn-primary btn-block" type="submit" value="Add">
+    </td>
+  </tr>
+</table>
+  </div>
+</div>
+</form>
+
+{% endblock %}

--- a/lvfs/components/templates/component-overview.html
+++ b/lvfs/components/templates/component-overview.html
@@ -195,18 +195,10 @@
     </div>
     <div class="card-text">
       <ul class="list-group">
-{% for attr in md.security_claim.attrs|sort() %}
+{% for claim in (md.autoclaims+md.claims)|sort() %}
         <li class="list-group-item">
-{% if attr.startswith('danger-') %}
-          <span class="fas fa-times-circle fs-2 text-danger"></span>
-{% elif attr.startswith('warning-') %}
-          <span class="fas fa-times-circle fs-2 text-warning"></span>
-{% elif attr.startswith('info-') %}
-          <span class="fas fa-info-circle fs-2 text-info"></span>
-{% else %}
-          <span class="fas fa-check-circle fs-2 text-success"></span>
-{% endif %}
-          {{md.security_claim.attrs[attr]}}
+          <span class="fs-2 {{claim.icon_css|join(' ')}}"></span>
+          {{claim.summary}}
         </li>
 {% endfor %}
       </ul>

--- a/lvfs/devices/templates/device-atom.xml
+++ b/lvfs/devices/templates/device-atom.xml
@@ -51,9 +51,9 @@
 {% endif %}
         <h2>Security</h2>
         <ul>
-{% for attr in fw.security_claim.attrs|sort() %}
+{% for claim in fw.autoclaims|sort() %}
           <li>
-            {{fw.security_claim.attrs[attr]}}
+            {{claim.summary}}
           </li>
 {% endfor %}
         </ul>

--- a/lvfs/devices/templates/device.html
+++ b/lvfs/devices/templates/device.html
@@ -105,18 +105,10 @@
     <div class="col col-sm-2 font-weight-bold">Security</div>
     <div class="col col-sm-10">
       <ul class="list-group">
-{% for attr in fw.security_claim.attrs|sort() %}
+{% for claim in (fw.autoclaims+fw.claims)|sort() %}
         <li class="list-group-item">
-{% if attr.startswith('danger-') %}
-          <span class="fas fa-times-circle fs-2 text-danger"></span>
-{% elif attr.startswith('warning-') %}
-          <span class="fas fa-times-circle fs-2 text-warning"></span>
-{% elif attr.startswith('info-') %}
-          <span class="fas fa-info-circle fs-2 text-info"></span>
-{% else %}
-          <span class="fas fa-check-circle fs-2 text-success"></span>
-{% endif %}
-          {{fw.security_claim.attrs[attr]}}
+          <span class="fs-2 {{claim.icon_css|join(' ')}}"></span>
+          {{claim.summary}}
         </li>
 {% endfor %}
       </ul>

--- a/lvfs/firmware/routes_test.py
+++ b/lvfs/firmware/routes_test.py
@@ -276,7 +276,7 @@ class LocalTestCase(LvfsTestCase):
         self.run_cron_firmware()
         rv = self.app.get('/lvfs/firmware/1/promote/testing',
                           follow_redirects=True)
-        assert b'>testing<' in rv.data, rv.data
+        assert b'>testing<' in rv.data, rv.data.decode()
         self.logout()
 
     def test_vendor_split_with_reparent(self):

--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -1471,7 +1471,7 @@ class ComponentClaim(db.Model):
 
     component_claim_id = Column(Integer, primary_key=True)
     component_id = Column(Integer, ForeignKey('components.component_id'), nullable=False, index=True)
-    claim_id = Column(Integer, ForeignKey('claims.claim_id'), nullable=True, index=True) # only until migrated
+    claim_id = Column(Integer, ForeignKey('claims.claim_id'), nullable=False, index=True)
     _unused_kind = Column('kind', Text, nullable=False)
     _unused_value = Column('value', Text, nullable=False)
 

--- a/lvfs/shards/routes_test.py
+++ b/lvfs/shards/routes_test.py
@@ -68,26 +68,28 @@ class LocalTestCase(LvfsTestCase):
         assert 'No claims exist yet' in rv.data.decode(), rv.data.decode()
 
         # add claim
+        rv = self.app.post('/lvfs/claims/create', data=dict(
+            kind='foobarbaz',
+            summary='foobarbaz',
+        ), follow_redirects=True)
+        assert b'Added claim' in rv.data, rv.data.decode()
         rv = self.app.post('/lvfs/shards/1/claim/create', data=dict(
             checksum='DEADBEEF',
-            kind='info-dave',
-            value='Dave',
+            claim_id=1,
         ), follow_redirects=True)
         assert b'Added claim' in rv.data, rv.data.decode()
 
         # add claim again
         rv = self.app.post('/lvfs/shards/1/claim/create', data=dict(
             checksum='DEADBEEF',
-            kind='info-bar',
-            value='Baz',
+            claim_id=1,
         ), follow_redirects=True)
         assert b'checksum already exists' in rv.data, rv.data.decode()
 
         # verify it exists
         rv = self.app.get('/lvfs/shards/1/claims')
         assert 'DEADBEEF' in rv.data.decode(), rv.data.decode()
-        assert 'info-dave' in rv.data.decode(), rv.data.decode()
-        assert 'Dave' in rv.data.decode(), rv.data.decode()
+        assert 'foobarbaz' in rv.data.decode(), rv.data.decode()
 
         # delete it
         rv = self.app.get('/lvfs/shards/1/claim/1/delete', follow_redirects=True)

--- a/lvfs/shards/templates/shard-claims.html
+++ b/lvfs/shards/templates/shard-claims.html
@@ -10,9 +10,8 @@
     <div class="card-title">Component Shard Claims</div>
 <table class="table">
   <tr class="row">
-    <th class="col col-sm-3">Checksum</th>
-    <th class="col col-sm-2">Compare</th>
-    <th class="col col-sm-5">Value</th>
+    <th class="col col-sm-6">Checksum</th>
+    <th class="col col-sm-4">Claim</th>
     <th class="col col-sm-2">&nbsp;</th>
   </tr>
 {% if claims|length == 0 %}
@@ -23,9 +22,8 @@
 {% else %}
 {% for claim in claims|sort(attribute='checksum') %}
   <tr class="row">
-    <td class="col col-sm-3"><code>{{claim.checksum|truncate(32, False, '…')}}</code></td>
-    <td class="col col-sm-2"><code>{{claim.kind}}</code></td>
-    <td class="col col-sm-5">{{claim.value|truncate(50, False, '…')}}</td>
+    <td class="col col-sm-6"><code>{{claim.checksum|truncate(64, False, '…')}}</code></td>
+    <td class="col col-sm-4"><code>{{claim.claim.summary}}</code></td>
     <td class="col col-sm-2">
       <a class="btn btn-block btn-danger"
         href="{{url_for('shards.route_shard_claim_delete',
@@ -40,14 +38,15 @@
     <form method="post" action="{{url_for('shards.route_shard_claim_create',
                                           component_shard_info_id=shard.component_shard_info_id)}}">
     <input type="hidden" name="csrf_token" value="{{csrf_token()}}"/>
-    <td class="col col-sm-3">
+    <td class="col col-sm-6">
       <input type="text" class="form-control" name="checksum" value="" placeholder="Checksum..." required>
     </td>
-    <td class="col col-sm-2">
-      <input type="text" class="form-control" name="kind" value="" placeholder="Key..." required>
-    </td>
-    <td class="col col-sm-5">
-      <input type="text" class="form-control" name="value" value="" placeholder="Value..." required>
+    <td class="col col-sm-4">
+    <select class="form-control" name="claim_id">
+{% for claim in claims_all %}
+      <option value="{{claim.claim_id}}">{{claim.summary}}</option>
+{% endfor %}
+    </select>
     </td>
     <td class="col col-sm-2">
       <input type="submit" class="btn btn-block btn-primary" value="Add">

--- a/lvfs/shards/templates/shard-details.html
+++ b/lvfs/shards/templates/shard-details.html
@@ -14,12 +14,13 @@
     <textarea type="text" class="form-control" name="description" rows="10">{{shard.description if shard.description}}</textarea>
   </div>
   <div class="form-group">
-    <label for="display_name">GUID Claim Kind:</label>
-    <input class="form-control" id="claim_kind" type="text" name="claim_kind" value="{{shard.claim_kind if shard.claim_kind}}">
-  </div>
-  <div class="form-group">
-    <label for="display_name">GUID Claim Description:</label>
-    <input class="form-control" id="claim_value" type="text" name="claim_value" value="{{shard.claim_value if shard.claim_value}}">
+    <label for="display_name">GUID Claim:</label>
+    <select class="form-control" name="claim_id">
+      <option value="" {{ 'selected' if shard.claim_id == 0 }}>None</option>
+{% for claim in claims %}
+      <option value="{{claim.claim_id}}" {{ 'selected' if shard.claim_id == claim.claim_id }}>{{claim.summary}}</option>
+{% endfor %}
+    </select>
   </div>
   <input type="submit" class="btn btn-primary btn-large" value="Modify">
 </form>

--- a/lvfs/templates/private.html
+++ b/lvfs/templates/private.html
@@ -149,6 +149,9 @@
             <li class="nav-item {{'active' if request.url_rule.endpoint == 'shards.route_list'}}">
               <a class="nav-link" href="{{url_for('shards.route_list')}}">Component Shards</a>
             </li>
+            <li class="nav-item {{'active' if request.url_rule.endpoint == 'claims.route_list'}}">
+              <a class="nav-link" href="{{url_for('claims.route_list')}}">Component Claims</a>
+            </li>
             <li class="nav-item {{'active' if request.url_rule.endpoint == 'agreements.route_list'}}">
               <a class="nav-link" href="{{url_for('agreements.route_list')}}">Agreements</a>
             </li>

--- a/migrations/versions/2885e0d3f684_claim_as_object_migrate.py
+++ b/migrations/versions/2885e0d3f684_claim_as_object_migrate.py
@@ -1,0 +1,52 @@
+"""
+
+Revision ID: 2885e0d3f684
+Revises: 9595113b929c
+Create Date: 2020-01-27 14:21:54.315165
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2885e0d3f684'
+down_revision = '9595113b929c'
+
+from alembic import op
+import sqlalchemy as sa
+
+from lvfs import db
+from lvfs.models import Claim, ComponentShardInfo, ComponentClaim
+
+def upgrade():
+
+    # add all the existing types
+    db.session.add(Claim(kind='computrace',
+                         icon='info',
+                         summary='Contains Absolute Computrace Agent'))
+    db.session.add(Claim(kind='hp-surestart',
+                         icon='success',
+                         summary='Contains HP Sure Start'))
+    db.session.add(Claim(kind='uefi-shell',
+                         icon='info',
+                         summary='Contains UEFI Shell'))
+    db.session.commit()
+
+    # map the old name to the new ID
+    claim_ids = {}
+    for claim in db.session.query(Claim):
+        claim_ids['{}-{}'.format(claim.icon, claim.kind)] = claim.claim_id
+    for shard_info in db.session.query(ComponentShardInfo):
+        if not shard_info._unused_claim_kind:
+            continue
+        shard_info.claim_id = claim_ids[shard_info._unused_claim_kind]
+    for component_claim in db.session.query(ComponentClaim):
+        component_claim.claim_id = claim_ids[component_claim._unused_kind]
+    db.session.commit()
+
+    op.alter_column('component_claims', 'claim_id',
+               existing_type=sa.INTEGER(),
+               nullable=False)
+
+def downgrade():
+    op.alter_column('component_claims', 'claim_id',
+               existing_type=sa.INTEGER(),
+               nullable=True)

--- a/migrations/versions/9595113b929c_claim_as_object.py
+++ b/migrations/versions/9595113b929c_claim_as_object.py
@@ -1,0 +1,47 @@
+"""
+
+Revision ID: 9595113b929c
+Revises: 58a8c79cd632
+Create Date: 2020-01-25 11:36:48.843219
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '9595113b929c'
+down_revision = '58a8c79cd632'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('claims',
+    sa.Column('claim_id', sa.Integer(), nullable=False),
+    sa.Column('kind', sa.Text(), nullable=False),
+    sa.Column('icon', sa.Text(), nullable=True),
+    sa.Column('summary', sa.Text(), nullable=True),
+    sa.Column('url', sa.Text(), nullable=True),
+    sa.PrimaryKeyConstraint('claim_id'),
+    mysql_character_set='utf8mb4'
+    )
+    op.create_index(op.f('ix_claims_kind'), 'claims', ['kind'], unique=False)
+    op.add_column('component_claims', sa.Column('claim_id', sa.Integer(), nullable=True))
+    op.create_index(op.f('ix_component_claims_claim_id'), 'component_claims', ['claim_id'], unique=False)
+    op.create_foreign_key(None, 'component_claims', 'claims', ['claim_id'], ['claim_id'])
+    op.add_column('component_shard_claims', sa.Column('claim_id', sa.Integer(), nullable=True))
+    op.create_foreign_key(None, 'component_shard_claims', 'claims', ['claim_id'], ['claim_id'])
+    op.add_column('component_shard_infos', sa.Column('claim_id', sa.Integer(), nullable=True))
+    op.create_index(op.f('ix_component_shard_infos_claim_id'), 'component_shard_infos', ['claim_id'], unique=False)
+    op.create_foreign_key(None, 'component_shard_infos', 'claims', ['claim_id'], ['claim_id'])
+
+def downgrade():
+    op.drop_constraint(None, 'component_shard_infos', type_='foreignkey')
+    op.drop_index(op.f('ix_component_shard_infos_claim_id'), table_name='component_shard_infos')
+    op.drop_column('component_shard_infos', 'claim_id')
+    op.drop_constraint(None, 'component_shard_claims', type_='foreignkey')
+    op.drop_column('component_shard_claims', 'claim_id')
+    op.drop_constraint(None, 'component_claims', type_='foreignkey')
+    op.drop_index(op.f('ix_component_claims_claim_id'), table_name='component_claims')
+    op.drop_column('component_claims', 'claim_id')
+    op.drop_index(op.f('ix_claims_kind'), table_name='claims')
+    op.drop_table('claims')

--- a/plugins/blocklist/rules/computrace.yar
+++ b/plugins/blocklist/rules/computrace.yar
@@ -4,7 +4,7 @@ rule ComputraceAgent
         license = "GPL-2.0+"
         description = "Contains Absolute Computrace Agent"
         fail = false
-        claim = "info-computrace"
+        claim = "computrace"
 
     strings:
         $a = {D1 E0 F5 8B 4D 0C 83 D1 00 8B EC FF 33 83 C3 04}


### PR DESCRIPTION
At the moment we just add a key=value attribute to each object that requires a
claim. This doesn't scale, and means we can never change claim icons from
something like 'info' to 'warning' without a database query that touches lots
of records in different tables. We also want to have a URL we can point the
user to for more information, for instance describing what BIOSGuard is,
and why it's a good thing.

To do this, create enumerated claim kinds that can be referenced by ID and
modified as required. We only really have a couple of existing claim types,
so we don't even need to worry too much about migrating data.