### PR TITLE
Allow creating a ComponentShardInfo manually

### DIFF
--- a/lvfs/shards/routes_test.py
+++ b/lvfs/shards/routes_test.py
@@ -103,5 +103,39 @@ class LocalTestCase(LvfsTestCase):
         rv = self.app.get('/lvfs/shards/1/claims')
         assert 'No claims exist yet' in rv.data.decode(), rv.data.decode()
 
+    def test_shard_create(self):
+
+        self.login()
+        rv = self.app.get('/lvfs/shards/')
+        assert 'd9d114ef-f40b-4d48-aaa0-a3dc99c9f5bd' not in rv.data.decode('utf-8'), rv.data
+
+        # create
+        rv = self.app.post('/lvfs/shards/create', data=dict(
+            guid='NOT-A-GUID',
+        ), follow_redirects=True)
+        assert b'Not a GUID' in rv.data, rv.data.decode()
+        rv = self.app.post('/lvfs/shards/create', data=dict(
+            guid='D9D114EF-F40B-4d48-AAA0-A3DC99C9F5BD',
+        ), follow_redirects=True)
+        assert b'Added shard' in rv.data, rv.data.decode()
+        rv = self.app.get('/lvfs/shards/')
+        assert 'd9d114ef-f40b-4d48-aaa0-a3dc99c9f5bd' in rv.data.decode('utf-8'), rv.data.decode()
+        rv = self.app.post('/lvfs/shards/create', data=dict(
+            guid='d9d114ef-f40b-4d48-aaa0-a3dc99c9f5bd',
+        ), follow_redirects=True)
+        assert b'Already exists' in rv.data, rv.data.decode()
+
+        # modify
+        rv = self.app.post('/lvfs/shards/1/modify', data=dict(
+            description='ACME',
+        ), follow_redirects=True)
+        assert b'Modified shard' in rv.data, rv.data.decode()
+        rv = self.app.get('/lvfs/shards/')
+        assert 'ACME' in rv.data.decode('utf-8'), rv.data.decode()
+
+        # show
+        rv = self.app.get('/lvfs/shards/', follow_redirects=True)
+        assert b'ACME' in rv.data, rv.data.decode()
+
 if __name__ == '__main__':
     unittest.main()

--- a/lvfs/shards/templates/shard-list.html
+++ b/lvfs/shards/templates/shard-list.html
@@ -39,4 +39,18 @@
 
 {% endif %}
 
+<div class="card mt-3">
+  <div class="card-body">
+    <div class="card-title">Create a new shard</div>
+    <form method="post" action="{{url_for('shards.route_create')}}" class="form">
+      <input type="hidden" name="csrf_token" value="{{csrf_token()}}"/>
+      <div class="form-group card-text">
+        <label>GUID</label>
+        <input class="form-control" type="text" name="guid" placeholder="9b3ada4f-ae56-4c24-8dea-f03b7558ae50" required />
+      </div>
+      <input class="card-link btn btn-primary" type="submit" value="Add"/>
+    </form>
+  </div>
+</div>
+
 {% endblock %}


### PR DESCRIPTION
If we want to add a Claim() on a component for a firmware that has not yet been
uploaded we need to be able to create the shard info manually.

This allows us to add 'danger'-class claims for GUIDs like SourceLevelDebugPkg
which should never exist on the LVFS.