### PR TITLE
Switch the plugin order_after() to a property

### DIFF
--- a/lvfs/pluginloader.py
+++ b/lvfs/pluginloader.py
@@ -57,6 +57,7 @@ class PluginBase:
         self._setting_kvs = {}
         self.name = 'Noname Plugin'
         self.summary = 'Plugin did not set summary'
+        self.order_after = []
 
     def settings(self):
         return []
@@ -134,12 +135,7 @@ class Pluginloader:
         # depsolve
         for plugin_name in plugins:
             plugin = plugins[plugin_name]
-            if not hasattr(plugin, 'order_after'):
-                continue
-            names = plugin.order_after()
-            if not names:
-                continue
-            for name in names:
+            for name in plugin.order_after:
                 if name not in plugins:
                     continue
                 plugin2 = plugins[name]

--- a/plugins/blocklist/__init__.py
+++ b/plugins/blocklist/__init__.py
@@ -51,9 +51,7 @@ class Plugin(PluginBase):
         self.rules = None
         self.name = 'Blocklist'
         self.summary = 'Use YARA to check firmware for problems'
-
-    def order_after(self):
-        return ['uefi-extract', 'intelme']
+        self.order_after = ['uefi-extract', 'intelme']
 
     def settings(self):
         s = []

--- a/plugins/pecheck/__init__.py
+++ b/plugins/pecheck/__init__.py
@@ -89,9 +89,7 @@ class Plugin(PluginBase):
         PluginBase.__init__(self, plugin_id)
         self.name = 'PE Check'
         self.summary = 'Check the portable executable file (.efi) for common problems'
-
-    def order_after(self):
-        return ['uefi-extract', 'intelme']
+        self.order_after = ['uefi-extract', 'intelme']
 
     def settings(self):
         s = []

--- a/plugins/shard-claim/__init__.py
+++ b/plugins/shard-claim/__init__.py
@@ -19,9 +19,7 @@ class Plugin(PluginBase):
         self.claims_by_csum = {}
         self.name = 'Shard Claim'
         self.summary = 'Add component claims based on shard GUIDs'
-
-    def order_after(self):
-        return ['uefi-extract']
+        self.order_after = ['uefi-extract']
 
     def ensure_test_for_fw(self, fw):
 


### PR DESCRIPTION
This is only static, and so we can save some overhead making it a property.