### PR TITLE
Add cached public stats of useful metrics

### DIFF
--- a/lvfs/main/routes_test.py
+++ b/lvfs/main/routes_test.py
@@ -86,6 +86,17 @@ class LocalTestCase(LvfsTestCase):
         assert b'bob@fwupd.org' in rv.data, rv.data
         assert b'mario@oem.com' in rv.data, rv.data
 
+    def test_metrics(self):
+
+        self.login()
+        self.upload()
+        self.logout()
+        self._download_firmware()
+        self.run_cron_stats()
+
+        rv = self.app.get('/lvfs/metrics')
+        assert b'ClientCnt": 1' in rv.data, rv.data.decode()
+
     def test_nologin_required(self):
 
         # all these are viewable without being logged in

--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -2462,6 +2462,17 @@ class Report(db.Model):
     def __repr__(self):
         return "Report object %s" % self.report_id
 
+class Metric(db.Model):
+
+    __tablename__ = 'metrics'
+
+    setting_id = Column(Integer, primary_key=True)
+    key = Column(Text, nullable=False)
+    value = Column(Integer, default=0)
+
+    def __repr__(self):
+        return 'Metric object {}={}'.format(self.key, self.value)
+
 class Setting(db.Model):
 
     __tablename__ = 'settings'

--- a/migrations/versions/c26f0a8c9572_add_metrics.py
+++ b/migrations/versions/c26f0a8c9572_add_metrics.py
@@ -1,0 +1,26 @@
+"""
+
+Revision ID: c26f0a8c9572
+Revises: e076643fdb96
+Create Date: 2020-02-03 17:55:03.987499
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'c26f0a8c9572'
+down_revision = 'e076643fdb96'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('metrics',
+    sa.Column('setting_id', sa.Integer(), nullable=False),
+    sa.Column('key', sa.Text(), nullable=False),
+    sa.Column('value', sa.Integer(), nullable=True),
+    sa.PrimaryKeyConstraint('setting_id')
+    )
+
+def downgrade():
+    op.drop_table('metrics')


### PR DESCRIPTION
I'm going to be polling this several times a minute for a cool as-yet-unreleased
hardware project, so cache these to avoid database load.