### PR TITLE
Do not show the raw iso3166 values in the firmware details

### DIFF
--- a/lvfs/firmware/templates/firmware-details.html
+++ b/lvfs/firmware/templates/firmware-details.html
@@ -173,7 +173,11 @@ new Chart(ctx, {
         </div>
         <p class="card-text">
           The firmware cannot be downloaded from users in these countries:
-          <code>{{fw.banned_country_codes}}</code>.
+          <ul>
+{% for country_code in fw.banned_country_codes.split(',') %}
+          <li>{{format_iso3166(country_code)}}</li>
+{% endfor %}
+          </ul>
         </p>
       </div>
     </div>


### PR DESCRIPTION
![Screenshot_2020-02-03 LVFS Firmware Details](https://user-images.githubusercontent.com/151380/73680063-830d5200-46b3-11ea-8877-8b423b4a6fe2.png)
