### PR TITLE
Actually include LVFS::UpdateProtocol in the metadata

### DIFF
--- a/lvfs/metadata/utils.py
+++ b/lvfs/metadata/utils.py
@@ -273,6 +273,10 @@ def _generate_metadata_kind(filename, fws, firmware_baseuri='', local=False):
                         elements.append(('LVFS::VersionFormat', fallback))
                 elements.append(('LVFS::VersionFormat', verfmt.value))
                 break
+        for md in mds:
+            if md.protocol:
+                elements.append(('LVFS::UpdateProtocol', md.protocol.value))
+                break
         if elements:
             parent = ET.SubElement(component, 'custom')
             for key, value in elements:


### PR DESCRIPTION
We are already checking this in fwupd when installing the downloaded file, but
for other tools that are just consuming the metadata it's very useful to have
it in the catalog too.