### PR TITLE
Rewrite the metainfo when signing the firmware

### DIFF
--- a/lvfs/components/routes.py
+++ b/lvfs/components/routes.py
@@ -181,6 +181,7 @@ def route_modify(component_id):
 
     # modify
     md.fw.mark_dirty()
+    md.fw.signed_timestamp = None
     db.session.commit()
     flash('Component updated', 'info')
     return redirect(url_for('components.route_show',
@@ -286,6 +287,7 @@ def route_requirement_delete(component_id, requirement_id):
     # remove chid
     db.session.delete(rq)
     md.fw.mark_dirty()
+    md.fw.signed_timestamp = None
     db.session.commit()
 
     # log
@@ -344,6 +346,7 @@ def route_requirement_create(component_id):
                      depth=depth)
     md.requirements.append(rq)
     md.fw.mark_dirty()
+    md.fw.signed_timestamp = None
     db.session.commit()
     flash('Added requirement', 'info')
     return redirect(url_for('components.route_show',
@@ -418,6 +421,7 @@ def route_requirement_modify(component_id):
                     )
     md.requirements.append(rq)
     md.fw.mark_dirty()
+    md.fw.signed_timestamp = None
     db.session.commit()
     flash('Added requirement', 'info')
     return redirect(url_for('components.route_show',
@@ -449,6 +453,7 @@ def route_keyword_delete(component_id, keyword_id):
     # remove chid
     db.session.delete(kw)
     md.fw.mark_dirty()
+    md.fw.signed_timestamp = None
     db.session.commit()
 
     # log
@@ -482,6 +487,7 @@ def route_keyword_create(component_id):
     # add keyword
     md.add_keywords_from_string(request.form['value'])
     md.fw.mark_dirty()
+    md.fw.signed_timestamp = None
     db.session.commit()
     flash('Added keywords', 'info')
     return redirect(url_for('components.route_show',
@@ -509,6 +515,7 @@ def route_issue_delete(component_id, component_issue_id):
     # remove issue
     db.session.delete(issue)
     md.fw.mark_dirty()
+    md.fw.signed_timestamp = None
     db.session.commit()
 
     # log
@@ -592,6 +599,7 @@ def route_issue_autoimport(component_id):
         flash('No issues could be detected', 'info')
     else:
         md.fw.mark_dirty()
+        md.fw.signed_timestamp = None
         db.session.commit()
         flash('Added {} issues — now review the update description for sanity'.format(n_issues), 'info')
     return redirect(url_for('components.route_show',
@@ -646,6 +654,7 @@ def route_issue_create(component_id):
         flash('Added {}'.format(value), 'info')
         md.issues.append(issue)
     md.fw.mark_dirty()
+    md.fw.signed_timestamp = None
     db.session.commit()
     return redirect(url_for('components.route_show',
                             component_id=md.component_id,
@@ -676,6 +685,7 @@ def route_checksum_delete(component_id, checksum_id):
 
     # remove chid
     md.fw.mark_dirty()
+    md.fw.signed_timestamp = None
     db.session.delete(csum)
     db.session.commit()
 
@@ -731,6 +741,7 @@ def route_checksum_create(component_id):
     csum = Checksum(kind=hash_kind, value=hash_value)
     md.device_checksums.append(csum)
     md.fw.mark_dirty()
+    md.fw.signed_timestamp = None
     db.session.commit()
     flash('Added device checksum', 'info')
     return redirect(url_for('components.route_show',

--- a/lvfs/components/templates/component-checksums.html
+++ b/lvfs/components/templates/component-checksums.html
@@ -4,6 +4,15 @@
 {% block nav %}{% include 'component-nav.html' %}{% endblock %}
 
 {% block content %}
+
+{% if md.fw.remote.is_public and md.check_acl('@modify-requirements') %}
+  <div class="alert alert-danger mt-1" role="alert">
+    This firmware has already been pushed to {{md.fw.remote.name}} and in this
+    target no modifications are possible.
+  </div>
+{% endif %}
+
+<fieldset {{ 'disabled="disabled"' if md.fw.remote.is_public }} >
 <div class="card">
   <div class="card-body">
     <h2 class="card-title">Device Checksums</h2>
@@ -90,5 +99,6 @@
 {% endif %}
   </div>
 </div>
+</fieldset>
 
 {% endblock %}

--- a/lvfs/components/templates/component-issues.html
+++ b/lvfs/components/templates/component-issues.html
@@ -4,6 +4,15 @@
 {% block nav %}{% include 'component-nav.html' %}{% endblock %}
 
 {% block content %}
+
+{% if md.fw.remote.is_public and md.check_acl('@modify-requirements') %}
+  <div class="alert alert-danger mt-1" role="alert">
+    This firmware has already been pushed to {{md.fw.remote.name}} and in this
+    target no modifications are possible.
+  </div>
+{% endif %}
+
+<fieldset {{ 'disabled="disabled"' if md.fw.remote.is_public }} >
 <div class="card">
   <div class="card-body">
     <h2 class="card-title">Issues</h2>
@@ -45,4 +54,5 @@
 </table>
   </div>
 </div>
+</fieldset>
 {% endblock %}

--- a/lvfs/components/templates/component-keywords.html
+++ b/lvfs/components/templates/component-keywords.html
@@ -4,6 +4,15 @@
 {% block nav %}{% include 'component-nav.html' %}{% endblock %}
 
 {% block content %}
+
+{% if md.fw.remote.is_public and md.check_acl('@modify-requirements') %}
+  <div class="alert alert-danger mt-1" role="alert">
+    This firmware has already been pushed to {{md.fw.remote.name}} and in this
+    target no modifications are possible.
+  </div>
+{% endif %}
+
+<fieldset {{ 'disabled="disabled"' if md.fw.remote.is_public }} >
 <div class="card">
   <div class="card-body">
     <h2 class="card-title">Search Keywords</h2>
@@ -39,4 +48,5 @@
 </table>
   </div>
 </div>
+</fieldset>
 {% endblock %}

--- a/lvfs/components/templates/component-overview.html
+++ b/lvfs/components/templates/component-overview.html
@@ -4,6 +4,15 @@
 {% block nav %}{% include 'component-nav.html' %}{% endblock %}
 
 {% block content %}
+
+{% if md.fw.remote.is_public and md.check_acl('@modify-requirements') %}
+  <div class="alert alert-danger mt-1" role="alert">
+    This firmware has already been pushed to {{md.fw.remote.name}} and in this
+    target no modifications are possible.
+  </div>
+{% endif %}
+
+<fieldset {{ 'disabled="disabled"' if md.fw.remote.is_public }} >
 <div class="card">
   <div class="bg-holder bg-card" style="background-image:url(/img/corner-1.png);"></div>
   <div class="card-body">
@@ -208,5 +217,6 @@
     </div>
   </div>
 </div>
+</fieldset>
 
 {% endblock %}

--- a/lvfs/components/templates/component-requires-advanced.html
+++ b/lvfs/components/templates/component-requires-advanced.html
@@ -4,6 +4,15 @@
 {% block nav %}{% include 'component-nav.html' %}{% endblock %}
 
 {% block content %}
+
+{% if md.fw.remote.is_public and md.check_acl('@modify-requirements') %}
+  <div class="alert alert-danger mt-1" role="alert">
+    This firmware has already been pushed to {{md.fw.remote.name}} and in this
+    target no modifications are possible.
+  </div>
+{% endif %}
+
+<fieldset {{ 'disabled="disabled"' if md.fw.remote.is_public }} >
 <div class="card">
   <div class="card-body">
 {% if md.has_complex_requirements %}
@@ -180,5 +189,6 @@
 {% endif %}
   </div>
 </div>
+</fieldset>
 
 {% endblock %}

--- a/lvfs/components/templates/component-requires.html
+++ b/lvfs/components/templates/component-requires.html
@@ -5,14 +5,14 @@
 
 {% block content %}
 
-{% if md.check_acl('@modify-requirements') %}
-{% if md.fw.remote.name == 'stable' and not g.user.check_acl('@admin') %}
+{% if md.fw.remote.is_public and md.check_acl('@modify-requirements') %}
   <div class="alert alert-danger mt-1" role="alert">
-    This firmware has <strong>already been pushed to stable</strong>.
+    This firmware has already been pushed to {{md.fw.remote.name}} and in this
+    target no modifications are possible.
   </div>
 {% endif %}
-{% endif %}
 
+<fieldset {{ 'disabled="disabled"' if md.fw.remote.is_public }} >
 <form class="form" action="{{url_for('components.route_requirement_modify', component_id=md.component_id)}}" method="POST" >
 <input type="hidden" name="csrf_token" value="{{csrf_token()}}"/>
 <input type="hidden" name="kind" value="firmware">
@@ -146,5 +146,6 @@
   </div>
 </div>
 </form>
+</fieldset>
 
 {% endblock %}

--- a/lvfs/components/templates/component-update.html
+++ b/lvfs/components/templates/component-update.html
@@ -4,6 +4,15 @@
 {% block nav %}{% include 'component-nav.html' %}{% endblock %}
 
 {% block content %}
+
+{% if md.fw.remote.is_public and md.check_acl('@modify-requirements') %}
+  <div class="alert alert-danger mt-1" role="alert">
+    This firmware has already been pushed to {{md.fw.remote.name}} and in this
+    target no modifications are possible.
+  </div>
+{% endif %}
+
+<fieldset {{ 'disabled="disabled"' if md.fw.remote.is_public }} >
 {% if md.fw.remote.name == 'stable' and not g.user.check_acl('@admin') %}
 <div class="alert alert-danger mt-1" role="alert">
   This firmware has <strong>already been pushed to stable</strong>.
@@ -127,4 +136,5 @@ Some new functionality has also been added:
 </div>
 
 {% endif %}
+</fieldset>
 {% endblock %}

--- a/lvfs/mdsync/routes.py
+++ b/lvfs/mdsync/routes.py
@@ -26,7 +26,8 @@ def _md_to_mdsync_dict(md):
     obj['component_id'] = md.component_id
     obj['status'] = md.fw.remote.icon_name
     if md.fw.remote.is_public:
-        obj['date'] = md.fw.signed_timestamp.isoformat()
+        if md.fw.signed_timestamp:
+            obj['date'] = md.fw.signed_timestamp.isoformat()
         if md.release_tag:
             obj['release_tag'] = md.release_tag
         if md.details_url:

--- a/lvfs/metadata/utils.py
+++ b/lvfs/metadata/utils.py
@@ -12,6 +12,7 @@ import gzip
 import hashlib
 
 from collections import defaultdict
+from datetime import date
 from lxml import etree as ET
 
 from lvfs import db
@@ -19,146 +20,147 @@ from lvfs import db
 from lvfs.models import Firmware, Remote
 from lvfs.util import _get_settings, _xml_from_markdown
 
-def _generate_metadata_kind(fws, firmware_baseuri='', local=False):
-    """ Generates AppStream metadata of a specific kind """
+def _generate_metadata_mds(mds, firmware_baseuri='', local=False, metainfo=False):
 
-    root = ET.Element('components')
-    root.set('origin', 'lvfs')
-    root.set('version', '0.9')
+    # assume all the components have the same parent firmware information
+    md = mds[0]
+    component = ET.Element('component')
+    component.set('type', 'firmware')
+    ET.SubElement(component, 'id').text = md.appstream_id
 
-    # build a map of appstream_id:mds
-    components = defaultdict(list)
-    for fw in sorted(fws, key=lambda fw: fw.mds[0].appstream_id):
-        for md in fw.mds:
-            components[md.appstream_id].append(md)
-
-    # process each component in version order, but only include the latest 5
-    # releases to keep the metadata size sane
-    for appstream_id in sorted(components):
-        mds = sorted(components[appstream_id], reverse=True)[:5]
-        # assume all the components have the same parent firmware information
-        md = mds[0]
-        component = ET.SubElement(root, 'component')
-        component.set('type', 'firmware')
-        ET.SubElement(component, 'id').text = md.appstream_id
-        # until all front ends support <category> and <name_variant_suffix> append both */
+    # until all front ends support <category> and <name_variant_suffix> append both */
+    if metainfo:
+        ET.SubElement(component, 'name').text = md.name
+        if md.name_variant_suffix:
+            ET.SubElement(component, 'name_variant_suffix').text = md.name_variant_suffix
+    else:
         ET.SubElement(component, 'name').text = md.name_with_category
-        #ET.SubElement(component, 'name_variant_suffix').text = md.name_variant_suffix
-        ET.SubElement(component, 'summary').text = md.summary
-        ET.SubElement(component, 'developer_name').text = md.developer_name
-        if md.description:
-            component.append(_xml_from_markdown(md.description))
-        ET.SubElement(component, 'project_license').text = md.project_license
-        if md.url_homepage:
-            child = ET.SubElement(component, 'url')
-            child.set('type', 'homepage')
-            child.text = md.url_homepage
-        for md in mds:
-            if md.priority:
-                component.set('priority', str(md.priority))
+    ET.SubElement(component, 'summary').text = md.summary
+    if md.description:
+        component.append(_xml_from_markdown(md.description))
+    for md in mds:
+        if md.priority:
+            component.set('priority', str(md.priority))
 
-        # add requires for each allowed vendor_ids
-        elements = {}
-        for md in mds:
-            if local:
-                break
-
-            # the vendor can upload to any hardware
-            vendor = md.fw.vendor_odm
-            if vendor.is_unrestricted:
+    # provides shared by all releases
+    elements = {}
+    for md in mds:
+        for guid in md.guids:
+            if guid.value in elements:
                 continue
-
-            # no restrictions in place!
-            if not vendor.restrictions:
-                child = ET.Element('firmware')
-                child.text = 'vendor-id'
-                child.set('compare', 'eq')
-                child.set('version', 'XXX:NEVER_GOING_TO_MATCH')
-                elements['vendor-id'] = child
-                continue
-
-            # allow specifying more than one ID
-            vendor_ids = [res.value for res in vendor.restrictions]
             child = ET.Element('firmware')
-            child.text = 'vendor-id'
-            if len(vendor_ids) == 1:
-                child.set('compare', 'eq')
+            child.set('type', 'flashed')
+            child.text = guid.value
+            elements[guid.value] = child
+    if elements:
+        parent = ET.SubElement(component, 'provides')
+        for key in sorted(elements):
+            parent.append(elements[key])
+
+    # shared again
+    if md.url_homepage:
+        child = ET.SubElement(component, 'url')
+        child.set('type', 'homepage')
+        child.text = md.url_homepage
+    if md.metadata_license:
+        ET.SubElement(component, 'metadata_license').text = md.metadata_license
+    ET.SubElement(component, 'project_license').text = md.project_license
+    ET.SubElement(component, 'developer_name').text = md.developer_name
+
+    # screenshot shared by all releases
+    elements = {}
+    for md in mds:
+        if not md.screenshot_url and not md.screenshot_caption:
+            continue
+        # try to dedupe using the URL and then the caption
+        key = md.screenshot_url
+        if not key:
+            key = md.screenshot_caption
+        if key not in elements:
+            child = ET.Element('screenshot')
+            if not elements:
+                child.set('type', 'default')
+            if md.screenshot_caption:
+                ET.SubElement(child, 'caption').text = md.screenshot_caption
+            if md.screenshot_url:
+                ET.SubElement(child, 'image').text = md.screenshot_url
+            elements[key] = child
+    if elements:
+        parent = ET.SubElement(component, 'screenshots')
+        for key in elements:
+            parent.append(elements[key])
+
+    # add enumerated categories
+    cats = []
+    for md in mds:
+        if not md.category:
+            continue
+        if md.category.value not in cats:
+            cats.append(md.category.value)
+        if md.category.fallbacks:
+            for fallback in md.category.fallbacks.split(','):
+                if fallback not in cats:
+                    cats.append(fallback)
+    if cats:
+        # use a non-standard prefix as we're still using .name_with_category
+        if metainfo:
+            categories = ET.SubElement(component, 'categories')
+        else:
+            categories = ET.SubElement(component, 'X-categories')
+        for cat in cats:
+            ET.SubElement(categories, 'category').text = cat
+
+    # metadata shared by all releases
+    elements = []
+    for md in mds:
+        if md.inhibit_download:
+            child = ET.Element('value')
+            child.set('key', 'LVFS::InhibitDownload')
+            elements.append(('LVFS::InhibitDownload', None))
+            break
+    for md in mds:
+        verfmt = md.verfmt_with_fallback
+        if verfmt:
+            if verfmt.fallbacks:
+                for fallback in verfmt.fallbacks.split(','):
+                    elements.append(('LVFS::VersionFormat', fallback))
+            elements.append(('LVFS::VersionFormat', verfmt.value))
+            break
+    for md in mds:
+        if md.protocol:
+            elements.append(('LVFS::UpdateProtocol', md.protocol.value))
+            break
+    if elements:
+        parent = ET.SubElement(component, 'custom')
+        for key, value in elements:
+            child = ET.Element('value')
+            child.set('key', key)
+            child.text = value
+            parent.append(child)
+
+    # add each release
+    releases = ET.SubElement(component, 'releases')
+    for md in mds:
+        if not md.version:
+            continue
+        rel = ET.SubElement(releases, 'release')
+        if md.version:
+            if metainfo and md.version.isdigit():
+                rel.set('version', hex(int(md.version)))
             else:
-                child.set('compare', 'regex')
-            child.set('version', '|'.join(vendor_ids))
-            elements['vendor-id'] = child
-
-        # add requires for <firmware> or fwupd version
-        for md in mds:
-            for rq in md.requirements:
-                if rq.kind == 'hardware':
-                    continue
-                child = ET.Element(rq.kind)
-                if rq.value:
-                    child.text = rq.value
-                if rq.compare:
-                    child.set('compare', rq.compare)
-                if rq.version:
-                    child.set('version', rq.version)
-                if rq.depth:
-                    child.set('depth', rq.depth)
-                elements[rq.kind + str(rq.value)] = child
-
-        # add a single requirement for <hardware>
-        rq_hws = []
-        for md in mds:
-            for rq in md.requirements:
-                if rq.kind == 'hardware' and rq.value not in rq_hws:
-                    rq_hws.append(rq.value)
-        if rq_hws:
-            child = ET.Element('hardware')
-            child.text = '|'.join(rq_hws)
-            elements['hardware'] = child
-
-        # requires shared by all releases
-        if elements:
-            parent = ET.SubElement(component, 'requires')
-            for key in elements:
-                parent.append(elements[key])
-
-        # screenshot shared by all releases
-        elements = {}
-        for md in mds:
-            if not md.screenshot_url and not md.screenshot_caption:
-                continue
-            # try to dedupe using the URL and then the caption
-            key = md.screenshot_url
-            if not key:
-                key = md.screenshot_caption
-            if key not in elements:
-                child = ET.Element('screenshot')
-                if not elements:
-                    child.set('type', 'default')
-                if md.screenshot_caption:
-                    ET.SubElement(child, 'caption').text = md.screenshot_caption
-                if md.screenshot_url:
-                    ET.SubElement(child, 'image').text = md.screenshot_url
-                elements[key] = child
-        if elements:
-            parent = ET.SubElement(component, 'screenshots')
-            for key in elements:
-                parent.append(elements[key])
-
-        # add each release
-        releases = ET.SubElement(component, 'releases')
-        for md in mds:
-            if not md.version:
-                continue
-            rel = ET.SubElement(releases, 'release')
-            if md.release_timestamp:
-                rel.set('timestamp', str(md.release_timestamp))
-            if md.release_urgency and md.release_urgency != 'unknown':
-                rel.set('urgency', md.release_urgency)
-            if md.version:
                 rel.set('version', md.version)
+        if md.release_timestamp:
+            if metainfo:
+                rel.set('date', date.fromtimestamp(md.release_timestamp).isoformat())
+            else:
+                rel.set('timestamp', str(md.release_timestamp))
+        if md.release_urgency and md.release_urgency != 'unknown':
+            rel.set('urgency', md.release_urgency)
+        if not metainfo:
             ET.SubElement(rel, 'location').text = firmware_baseuri + md.fw.filename
 
-            # add container checksum
+        # add container checksum
+        if not metainfo:
             if md.fw.checksum_signed_sha1 or local:
                 csum = ET.SubElement(rel, 'checksum')
                 #metadata intended to be used locally won't be signed
@@ -179,118 +181,171 @@ def _generate_metadata_kind(fws, firmware_baseuri='', local=False):
                 csum.set('filename', md.fw.filename)
                 csum.set('target', 'container')
 
-            # add content checksum
-            if md.checksum_contents_sha1:
-                csum = ET.SubElement(rel, 'checksum')
-                csum.text = md.checksum_contents_sha1
-                csum.set('type', 'sha1')
-                csum.set('filename', md.filename_contents)
-                csum.set('target', 'content')
-            if md.checksum_contents_sha256:
-                csum = ET.SubElement(rel, 'checksum')
-                csum.text = md.checksum_contents_sha256
-                csum.set('type', 'sha256')
-                csum.set('filename', md.filename_contents)
-                csum.set('target', 'content')
+        # add content checksum
+        if md.checksum_contents_sha1:
+            csum = ET.SubElement(rel, 'checksum')
+            csum.text = md.checksum_contents_sha1
+            csum.set('type', 'sha1')
+            csum.set('filename', md.filename_contents)
+            csum.set('target', 'content')
+        if md.checksum_contents_sha256:
+            csum = ET.SubElement(rel, 'checksum')
+            csum.text = md.checksum_contents_sha256
+            csum.set('type', 'sha256')
+            csum.set('filename', md.filename_contents)
+            csum.set('target', 'content')
 
-            # add all device checksums
-            for csum in md.device_checksums:
-                n_csum = ET.SubElement(rel, 'checksum')
-                n_csum.text = csum.value
-                n_csum.set('type', csum.kind.lower())
-                n_csum.set('target', 'device')
+        # add all device checksums
+        for csum in md.device_checksums:
+            n_csum = ET.SubElement(rel, 'checksum')
+            n_csum.text = csum.value
+            n_csum.set('type', csum.kind.lower())
+            n_csum.set('target', 'device')
 
-            # add long description
-            if md.release_description:
-                markdown = md.release_description
-                if md.issues:
-                    markdown += '\n'
-                    markdown += 'Security issues fixed:\n'
-                    for issue in md.issues:
-                        markdown += ' * {}\n'.format(issue.value)
-                rel.append(_xml_from_markdown(markdown))
+        # add long description
+        if md.release_description:
+            markdown = md.release_description
+            if md.issues and not metainfo:
+                markdown += '\n'
+                markdown += 'Security issues fixed:\n'
+                for issue in md.issues:
+                    markdown += ' * {}\n'.format(issue.value)
+            rel.append(_xml_from_markdown(markdown))
 
-            # add details URL if set
-            if md.details_url:
-                child = ET.SubElement(rel, 'url')
-                child.set('type', 'details')
-                child.text = md.details_url
+        # add details URL if set
+        if md.details_url:
+            child = ET.SubElement(rel, 'url')
+            child.set('type', 'details')
+            child.text = md.details_url
 
-            # add source URL if set
-            if md.source_url:
-                child = ET.SubElement(rel, 'url')
-                child.set('type', 'source')
-                child.text = md.source_url
+        # add source URL if set
+        if md.source_url:
+            child = ET.SubElement(rel, 'url')
+            child.set('type', 'source')
+            child.text = md.source_url
 
-            # add sizes if set
-            if md.release_installed_size:
-                sz = ET.SubElement(rel, 'size')
-                sz.set('type', 'installed')
-                sz.text = str(md.release_installed_size)
-            if md.release_download_size:
-                sz = ET.SubElement(rel, 'size')
-                sz.set('type', 'download')
-                sz.text = str(md.release_download_size)
+        # add sizes if set
+        if md.release_installed_size:
+            sz = ET.SubElement(rel, 'size')
+            sz.set('type', 'installed')
+            sz.text = str(md.release_installed_size)
+        if not metainfo and md.release_download_size:
+            sz = ET.SubElement(rel, 'size')
+            sz.set('type', 'download')
+            sz.text = str(md.release_download_size)
 
-        # add enumerated categories
-        cats = []
+        # add issues
+        if metainfo and md.issues:
+            issues = ET.SubElement(rel, 'issues')
+            for issue in md.issues:
+                category = ET.SubElement(issues, 'issue')
+                category.text = issue.value
+                category.set('type', issue.kind)
+
+    # add requires for each allowed vendor_ids
+    elements = []
+    if not metainfo and not local:
         for md in mds:
-            if not md.category:
+
+            # the vendor can upload to any hardware
+            vendor = md.fw.vendor_odm
+            if vendor.is_unrestricted:
                 continue
-            if md.category.value not in cats:
-                cats.append(md.category.value)
-            if md.category.fallbacks:
-                for fallback in md.category.fallbacks.split(','):
-                    if fallback not in cats:
-                        cats.append(fallback)
-        if cats:
-            # use a non-standard prefix as we're still using .name_with_category
-            categories = ET.SubElement(root, 'X-categories')
-            for cat in cats:
-                ET.SubElement(categories, 'category').text = cat
 
-        # provides shared by all releases
-        elements = {}
-        for md in mds:
-            for guid in md.guids:
-                if guid.value in elements:
-                    continue
+            # no restrictions in place!
+            if not vendor.restrictions:
                 child = ET.Element('firmware')
-                child.set('type', 'flashed')
-                child.text = guid.value
-                elements[guid.value] = child
-        if elements:
-            parent = ET.SubElement(component, 'provides')
-            for key in sorted(elements):
-                parent.append(elements[key])
+                child.text = 'vendor-id'
+                child.set('compare', 'eq')
+                child.set('version', 'XXX:NEVER_GOING_TO_MATCH')
+                elements.append(child)
+                continue
 
-        # metadata shared by all releases
-        elements = []
+            # allow specifying more than one ID
+            vendor_ids = [res.value for res in vendor.restrictions]
+            child = ET.Element('firmware')
+            child.text = 'vendor-id'
+            if len(vendor_ids) == 1:
+                child.set('compare', 'eq')
+            else:
+                child.set('compare', 'regex')
+            child.set('version', '|'.join(vendor_ids))
+            elements.append(child)
+
+    # add requires for <firmware> or fwupd version
+    for md in mds:
+        for rq in md.requirements:
+            if rq.kind == 'hardware':
+                continue
+            child = ET.Element(rq.kind)
+            if rq.value:
+                child.text = rq.value
+            if rq.compare:
+                child.set('compare', rq.compare)
+            if rq.version:
+                child.set('version', rq.version)
+            if rq.depth:
+                child.set('depth', rq.depth)
+            elements.append(child)
+
+    # add a single requirement for <hardware>
+    rq_hws = []
+    for md in mds:
+        for rq in md.requirements:
+            if rq.kind == 'hardware' and rq.value not in rq_hws:
+                rq_hws.append(rq.value)
+    if rq_hws:
+        child = ET.Element('hardware')
+        child.text = '|'.join(rq_hws)
+        elements.append(child)
+
+    # requires shared by all releases
+    if elements:
+        parent = ET.SubElement(component, 'requires')
+        for element in elements:
+            parent.append(element)
+
+    # keywords shared by all releases
+    if metainfo:
+        keywords = []
         for md in mds:
-            if md.inhibit_download:
-                child = ET.Element('value')
-                child.set('key', 'LVFS::InhibitDownload')
-                elements.append(('LVFS::InhibitDownload', None))
-                break
-        for md in mds:
-            verfmt = md.verfmt_with_fallback
-            if verfmt:
-                if verfmt.fallbacks:
-                    for fallback in verfmt.fallbacks.split(','):
-                        elements.append(('LVFS::VersionFormat', fallback))
-                elements.append(('LVFS::VersionFormat', verfmt.value))
-                break
-        for md in mds:
-            if md.protocol:
-                elements.append(('LVFS::UpdateProtocol', md.protocol.value))
-                break
-        if elements:
-            parent = ET.SubElement(component, 'custom')
-            for key, value in elements:
-                child = ET.Element('value')
-                child.set('key', key)
-                child.text = value
+            for kw in md.keywords:
+                if kw.priority != 5:
+                    continue
+                if kw.value in keywords:
+                    continue
+                keywords.append(kw.value)
+        if keywords:
+            parent = ET.SubElement(component, 'keywords')
+            for keyword in keywords:
+                child = ET.Element('keyword')
+                child.text = keyword
                 parent.append(child)
+
+    # success
+    return component
+
+def _generate_metadata_kind(fws, firmware_baseuri='', local=False):
+    """ Generates AppStream metadata of a specific kind """
+
+    root = ET.Element('components')
+    root.set('origin', 'lvfs')
+    root.set('version', '0.9')
+
+    # build a map of appstream_id:mds
+    components = defaultdict(list)
+    for fw in sorted(fws, key=lambda fw: fw.mds[0].appstream_id):
+        for md in fw.mds:
+            components[md.appstream_id].append(md)
+
+    # process each component in version order, but only include the latest 5
+    # releases to keep the metadata size sane
+    for appstream_id in sorted(components):
+        mds = sorted(components[appstream_id], reverse=True)[:5]
+        component = _generate_metadata_mds(mds,
+                                           firmware_baseuri=firmware_baseuri,
+                                           local=local)
+        root.append(component)
 
     # dump to file
     return gzip.compress(ET.tostring(root, encoding='utf-8', xml_declaration=True))

--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -1839,18 +1839,12 @@ class Component(db.Model):
             return True
 
         # depends on the action requested
-        if action == '@modify-updateinfo':
+        if action in ('@modify-keywords', '@modify-requirements', '@modify-checksums', '@modify-updateinfo'):
             if not self.fw.remote.is_public:
                 if user.check_acl('@qa') and self.fw._is_permitted_action(action, user):
                     return True
                 if self.fw._is_owner(user):
                     return True
-            return False
-        if action in ('@modify-keywords', '@modify-requirements', '@modify-checksums'):
-            if user.check_acl('@qa') and self.fw._is_permitted_action(action, user):
-                return True
-            if self.fw._is_owner(user):
-                return True
             return False
         raise NotImplementedError('unknown security check action: %s:%s' % (self, action))
 

--- a/lvfs/upload/uploadedfile.py
+++ b/lvfs/upload/uploadedfile.py
@@ -231,7 +231,7 @@ class UploadedFile:
             md.release_tag = release.attrib['tag']
             if len(md.release_tag) < 4:
                 raise MetadataInvalid('<release> tag was too short to identify the firmware')
-            md.add_keywords_from_string(md.release_tag, priority=5)
+            md.add_keywords_from_string(md.release_tag, priority=6)
 
         # get list of CVEs
         for issue in release.xpath('issues/issue'):


### PR DESCRIPTION
One of the common tripping points for OEMs and ODMs is that the uploaded
firmware.metainfo.xml does not get rewritten if requirements are added or other
changes are made on the LVFS UI.

Although we use the metadata to know what firmware file to download, we use
the 'as uploaded' metadata when actually installing the firmware. By rewriting
the metainfo we can ensure the two information sources match.

This does of course change the downloaded file checksum, but this is not being
served by the CDN.