### PR TITLE
Delete firmware in embargo with newer public versions

### DIFF
--- a/lvfs/templates/email-firmware-obsolete.txt
+++ b/lvfs/templates/email-firmware-obsolete.txt
@@ -1,0 +1,23 @@
+Dear {{ user.display_name }},
+
+Firmware you uploaded to the Linux Vendor Firmware Service over 6 months ago has been automatically deleted as a newer version now exists in testing or stable:
+{% for fw in fws %}
+ * {{fw.md_prio.name}} version {{fw.md_prio.version_display}}
+{%- endfor %}
+
+The firmware can still be undeleted and then pushed to testing or stable as appropriate.
+
+Providing old versions of firmware is sometimes important to allow users to downgrade, or to allow building the complete set of release notes for a specific device. In general, it is better to push to stable than let the firmware be deleted.
+
+Note: Promoting an old firmware version to testing or stable will not cause additional downloads as updates are calculated by comparing the version number rather than the date the firmware was uploaded or promoted.
+
+You can log into the LVFS and view the firmware here:
+{% for fw in fws %}
+ * {{url_for('firmware.route_show', firmware_id=fw.firmware_id, _external=True)}}
+{%- endfor %}
+
+After an additional 6 months firmware that remains in the deleted state will be purged.
+
+Regards,
+
+The LVFS admins


### PR DESCRIPTION
There are hundreds of forgotten firmware files sitting in embargo where newer
versions exist in either testing or stable. Delete them, sending email, so that
users either undelete and move to stable, or allow them to be auto-purged after
an additional three months.