### PR TITLE
Rewrite the AppStream screenshot URL to use the server CDN

### DIFF
--- a/lvfs/metadata/utils.py
+++ b/lvfs/metadata/utils.py
@@ -51,6 +51,12 @@ def _use_hex_release_version(md):
         return False
     return True
 
+def _rewrite_url(url):
+    settings = _get_settings('firmware')
+    basename = '{}-{}'.format(hashlib.sha256(url.encode()).hexdigest(),
+                              os.path.basename(url))
+    return os.path.join(settings['firmware_baseuri_cdn'], basename)
+
 def _generate_metadata_mds(mds, firmware_baseuri='', local=False, metainfo=False):
 
     # assume all the components have the same parent firmware information
@@ -114,7 +120,10 @@ def _generate_metadata_mds(mds, firmware_baseuri='', local=False, metainfo=False
             if md.screenshot_caption:
                 ET.SubElement(child, 'caption').text = md.screenshot_caption
             if md.screenshot_url:
-                ET.SubElement(child, 'image').text = md.screenshot_url
+                if metainfo:
+                    ET.SubElement(child, 'image').text = md.screenshot_url
+                else:
+                    ET.SubElement(child, 'image').text = _rewrite_url(md.screenshot_url)
             elements[key] = child
     if elements:
         parent = ET.SubElement(component, 'screenshots')

--- a/lvfs/pluginloader.py
+++ b/lvfs/pluginloader.py
@@ -101,6 +101,8 @@ class PluginGeneral(PluginBase):
                                    'This is a test instance and may be broken at any time.'))
         s.append(PluginSettingText('firmware_baseuri', 'Firmware BaseURI',
                                    'https://fwupd.org/downloads/'))
+        s.append(PluginSettingText('firmware_baseuri_cdn', 'Firmware CDN BaseURI',
+                                   'https://cdn.fwupd.org/downloads/'))
         s.append(PluginSettingTextList('hwinfo_kinds', 'Allowed hwinfo Types', ['nvme']))
         s.append(PluginSettingInteger('default_failure_minimum', 'Report failures required to demote', 5))
         s.append(PluginSettingInteger('default_failure_percentage', 'Report failures threshold for demotion', 70))


### PR DESCRIPTION
When the screenshot image is loaded on the client system we download the file
from the vendor specified URL. This would cause the client to ping an external
vendor on firmware install, leaking the user agent and IP address.

This probably is not what the user is expecting and certainly not mentioned in
our privacy policy.

Download the image locally when building the metadata, and rewrite the URL in
the public metadata to use the server CDN instead, fixing the privacy issue.