### PR TITLE
Rewrite the AppStream screenshot URL to use the server CDN

### DIFF
--- a/lvfs/metadata/utils.py
+++ b/lvfs/metadata/utils.py
@@ -114,7 +114,10 @@ def _generate_metadata_mds(mds, firmware_baseuri='', local=False, metainfo=False
             if md.screenshot_caption:
                 ET.SubElement(child, 'caption').text = md.screenshot_caption
             if md.screenshot_url:
-                ET.SubElement(child, 'image').text = md.screenshot_url
+                if metainfo or not md.screenshot_url_safe:
+                    ET.SubElement(child, 'image').text = md.screenshot_url
+                else:
+                    ET.SubElement(child, 'image').text = md.screenshot_url_safe
             elements[key] = child
     if elements:
         parent = ET.SubElement(component, 'screenshots')

--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -1409,6 +1409,7 @@ class Component(db.Model):
     release_urgency = Column(Text, default=None)
     release_tag = Column(Text, default=None)
     screenshot_url = Column(Text, default=None)
+    screenshot_url_safe = Column(Text, default=None)
     screenshot_caption = Column(Text, default=None)
     inhibit_download = Column(Boolean, default=False)
     verfmt_id = Column(Integer, ForeignKey('verfmts.verfmt_id'))

--- a/lvfs/pluginloader.py
+++ b/lvfs/pluginloader.py
@@ -101,6 +101,8 @@ class PluginGeneral(PluginBase):
                                    'This is a test instance and may be broken at any time.'))
         s.append(PluginSettingText('firmware_baseuri', 'Firmware BaseURI',
                                    'https://fwupd.org/downloads/'))
+        s.append(PluginSettingText('firmware_baseuri_cdn', 'Firmware CDN BaseURI',
+                                   'https://cdn.fwupd.org/downloads/'))
         s.append(PluginSettingTextList('hwinfo_kinds', 'Allowed hwinfo Types', ['nvme']))
         s.append(PluginSettingInteger('default_failure_minimum', 'Report failures required to demote', 5))
         s.append(PluginSettingInteger('default_failure_percentage', 'Report failures threshold for demotion', 70))

--- a/plugins/cdn-mirror/__init__.py
+++ b/plugins/cdn-mirror/__init__.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019 Richard Hughes <richard@hughsie.com>
+#
+# SPDX-License-Identifier: GPL-2.0+
+#
+# pylint: disable=no-self-use
+
+import os
+import hashlib
+from io import BytesIO
+import requests
+from PIL import Image, UnidentifiedImageError
+
+from lvfs import app
+from lvfs.pluginloader import PluginBase, PluginError, PluginSettingBool
+from lvfs.models import Test
+from lvfs.util import _get_settings
+
+class Plugin(PluginBase):
+    def __init__(self):
+        PluginBase.__init__(self)
+        self.name = 'CDN Mirror'
+        self.summary = 'Mirror screenshots on the CDN for privacy'
+
+    def settings(self):
+        s = []
+        s.append(PluginSettingBool('cdn_mirror_enable', 'Enabled', True))
+        return s
+
+    def require_test_for_md(self, md):
+        if not md.screenshot_url:
+            return False
+        return True
+
+    def ensure_test_for_fw(self, fw):
+
+        # add if not already exists
+        test = fw.find_test_by_plugin_id(self.id)
+        if not test:
+            test = Test(plugin_id=self.id, waivable=False)
+            fw.tests.append(test)
+
+    def run_test_on_md(self, test, md):
+
+        # download
+        try:
+            r = requests.get(md.screenshot_url)
+            r.raise_for_status()
+        except requests.exceptions.RequestException as e:
+            test.add_fail('Download', str(e))
+            return
+        test.add_pass('Download', md.screenshot_url)
+
+        # load as a PNG
+        try:
+            im = Image.open(BytesIO(r.content))
+        except UnidentifiedImageError as e:
+            test.add_fail('Parse', str(e))
+            return
+        if im.width > 600 or im.height > 400:
+            test.add_fail('Size', '{}x{} is too large'.format(im.width, im.height))
+        elif im.width < 300 or im.height < 100:
+            test.add_fail('Size', '{}x{} is too small'.format(im.width, im.height))
+        else:
+            test.add_pass('Size', '{}x{}'.format(im.width, im.height))
+
+        # save to download directory
+        basename = 'img-{}.png'.format(hashlib.sha256(r.content).hexdigest())
+        fn = os.path.join(app.config['DOWNLOAD_DIR'], basename)
+        if not os.path.isfile(fn):
+            im.save(fn, "PNG")
+
+        # set the safe URL
+        settings = _get_settings('firmware')
+        md.screenshot_url_safe = os.path.join(settings['firmware_baseuri_cdn'], basename)
+
+# run with PYTHONPATH=. ./env/bin/python3 plugins/cdn-mirror/__init__.py
+if __name__ == '__main__':
+    import sys
+    from lvfs.models import Firmware, Component
+
+    plugin = Plugin()
+    _test = Test(plugin_id=plugin.id)
+    _fw = Firmware()
+    _md = Component()
+    _md.screenshot_url = 'https://github.com/fwupd/8bitdo-firmware/raw/master/screenshots/FC30.png'
+    _fw.mds.append(_md)
+    plugin.run_test_on_md(_test, _md)
+    print('new URL', _md.screenshot_url_safe)
+    for attribute in _test.attributes:
+        print(attribute)

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,7 @@ pycparser==2.20
 PyGObject==3.36.0
 pylint==2.4.4
 pyparsing==2.4.6
+Pillow==7.1.0
 PyQRCode==1.2.1
 pyserial==3.4
 pytest==5.4.1


### PR DESCRIPTION
When the screenshot image is loaded on the client system we download the file
from the vendor specified URL. This would cause the client to ping an external
vendor on firmware install, leaking the user agent and IP address.

This probably is not what the user is expecting and certainly not mentioned in
our privacy policy.

Download the image locally when running tests, and use a CDN URL in the public
metadata, fixing the privacy issue.