### PR TITLE
Write metadata with a build suffix to prevent CDN mismatch

### DIFF
--- a/lvfs/metadata/routes.py
+++ b/lvfs/metadata/routes.py
@@ -41,7 +41,7 @@ def route_remote(group_id):
     remote.append('Enabled=true')
     remote.append('Title=Embargoed for ' + group_id)
     remote.append('Keyring=gpg')
-    remote.append('MetadataURI=https://fwupd.org/downloads/%s' % vendor.remote.filename)
+    remote.append('MetadataURI=https://fwupd.org/downloads/%s' % vendor.remote.filename_newest)
     remote.append('ReportURI=https://fwupd.org/lvfs/firmware/report')
     remote.append('OrderBefore=lvfs,fwupd')
     fn = group_id + '-embargo.conf'

--- a/lvfs/metadata/templates/metadata.html
+++ b/lvfs/metadata/templates/metadata.html
@@ -71,8 +71,8 @@
     <h2 class="card-title">
       {{v.display_name_with_team}} Embargo
       <span class="badge badge-warning">Private</span>
-      <a class="float-right" href="/downloads/{{v.remote.filename}}">
-        <code>{{v.remote.filename[:16]}}</code>
+      <a class="float-right" href="/downloads/{{v.remote.filename_newest}}">
+        <code>{{v.remote.filename_newest}}</code>
       </a>
     </h2>
     <p class="card-text">

--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -1910,7 +1910,23 @@ class Remote(db.Model):
         return self.name != 'deleted' and self.name != 'private'
 
     @property
+    def build_str(self):
+        if not self.build_cnt:
+            return '00000'
+        return '{:05d}'.format(self.build_cnt)
+
+    @property
     def filename(self):
+        if self.name == 'private':
+            return None
+        if self.name == 'stable':
+            return 'firmware-{}-stable.xml.gz'.format(self.build_str)
+        if self.name == 'testing':
+            return 'firmware-{}-testing.xml.gz'.format(self.build_str)
+        return 'firmware-{}-{}.xml.gz'.format(self.build_str, _qa_hash(self.name[8:]))
+
+    @property
+    def filename_newest(self):
         if self.name == 'private':
             return None
         if self.name == 'stable':


### PR DESCRIPTION
When a fwupd client wants to refresh the metadata it firsts download the tiny
signature (typically a JCat file) and then if that has changed compared to the
existing signature on disk the much larged gzipped XML metadata catalog is then
downloaded. This saves a lot of mirror bandwidth as some remotes do not change
very much, and even stable only regenerates 4 times a day.

The drawback of this is that we have two things that need to be used to verify
a signature, and one of four scenarios could happen:

 1. The same version of sig and catalog are delivered by the CDN

 2. Between getting the sig the remote is resigned and the CDN is invalidated

 3. The CDN sends an older cached version of the sig and the current catalog

 4. The CDN sends the current sig and a cached older version of the catalog

Over the last few years the first scenario happens 99.999999% of the time, but
0.000001 * millions of daily downloads means that the bug tracking the CDN issue
gets "me too"'d almost every week.

To fix the 3 failure scenarios, do three things:

 * Write each metadata catalog as a new file with a unique URL for the CDN

 * Write the name of the unique file in the JCat file so the client knows what
   to download with an alias for the old name for our future selves.

 * Delete old metadata catalogs, leaving the last 5 builds.

In scenarios 2 and 3 we just download the n-1 metadata catalog, which is fine,
and scenario 4 is now impossible as the URLs are now different.

Fixes the server side of https://github.com/fwupd/fwupd/issues/391