### PR TITLE
Add support for LVFS::UpdateMessage

### DIFF
--- a/lvfs/components/routes.py
+++ b/lvfs/components/routes.py
@@ -173,6 +173,8 @@ def route_modify(component_id):
         md.name_variant_suffix = request.form['name_variant_suffix']
     if 'release_tag' in request.form:
         md.release_tag = request.form['release_tag']
+    if 'release_message' in request.form:
+        md.release_message = request.form['release_message']
 
     # the firmware changed protocol
     if retry_all_tests:

--- a/lvfs/components/templates/component-update.html
+++ b/lvfs/components/templates/component-update.html
@@ -95,6 +95,13 @@
         The optional URL listed here should refer specifically to this firmware release.
       </p>
   </div>
+  <div class="form-group">
+    <label for="release_message">Update Message</label>
+      <input class="form-control" type="text" name="release_message" value="{{md.release_message if md.release_message}}"/>
+      <p class="text-secondary">
+        The update message may be shown when the firmware update has completed.
+      </p>
+  </div>
 {% if md.requires_source_url or md.source_url %}
   <div class="form-group">
     <label for="source_url">Source URL</label>

--- a/lvfs/metadata/utils.py
+++ b/lvfs/metadata/utils.py
@@ -148,9 +148,11 @@ def _generate_metadata_mds(mds, firmware_baseuri='', local=False, metainfo=False
     elements = []
     for md in mds:
         if md.inhibit_download:
-            child = ET.Element('value')
-            child.set('key', 'LVFS::InhibitDownload')
             elements.append(('LVFS::InhibitDownload', None))
+            break
+    for md in mds:
+        if md.release_message:
+            elements.append(('LVFS::UpdateMessage', md.release_message))
             break
     for md in mds:
         verfmt = md.verfmt_with_fallback

--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -1408,6 +1408,7 @@ class Component(db.Model):
     release_download_size = Column(Integer, default=0)
     release_urgency = Column(Text, default=None)
     release_tag = Column(Text, default=None)
+    release_message = Column(Text, default=None) # LVFS::UpdateMessage
     screenshot_url = Column(Text, default=None)
     screenshot_url_safe = Column(Text, default=None)
     screenshot_caption = Column(Text, default=None)

--- a/lvfs/upload/uploadedfile.py
+++ b/lvfs/upload/uploadedfile.py
@@ -529,6 +529,14 @@ class UploadedFile:
         except IndexError as _:
             pass
 
+        # allows OEM to set the update message
+        try:
+            text = _node_validate_text(component.xpath('custom/value[@key="LVFS::UpdateMessage"]')[0],
+                                       minlen=8, maxlen=1000, nourl=True)
+            md.release_message = text
+        except IndexError as _:
+            pass
+
         # should we parse the .inf file?
         try:
             text = _node_validate_text(component.xpath('custom/value[@key="LVFS::EnableInfParsing"]')[0],

--- a/migrations/versions/6e1c3e4cfe3c_release_message.py
+++ b/migrations/versions/6e1c3e4cfe3c_release_message.py
@@ -1,0 +1,22 @@
+"""
+
+Revision ID: 6e1c3e4cfe3c
+Revises: 57315c468b88
+Create Date: 2020-04-10 10:20:26.701796
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '6e1c3e4cfe3c'
+down_revision = '57315c468b88'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('components', sa.Column('release_message', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('components', 'release_message')


### PR DESCRIPTION
Vendors are uploading firmware with this metadata tag set, and it's being
stripped out when we re-write the metainfo.xml during signing.