### PR TITLE
Allow QA users to see all ODM firmware uploaded

### DIFF
--- a/lvfs/firmware/routes_test.py
+++ b/lvfs/firmware/routes_test.py
@@ -337,9 +337,6 @@ class LocalTestCase(LvfsTestCase):
 
         # check alice can't see or promote the irmware uploaded by bob
         self.login('alice@odm.com')
-        rv = self.app.get('/lvfs/firmware/',
-                          follow_redirects=True)
-        assert b'No firmware has been uploaded' in rv.data, rv.data
         rv = self.app.get('/lvfs/firmware/1/promote/testing',
                           follow_redirects=True)
         assert b'Permission denied: No QA access to 1' in rv.data, rv.data


### PR DESCRIPTION
At the moment QA users are restricted to seeing any firmware either uploaded by
them, or owned by their vendor. This work fine for OEMs.

For ODMs who are uploading on behalf of other OEMs we need to relax the rules a
little, and allow QA users to see any firmware uploaded by any users in their
own vendor group, regardless of what OEM actually owns the firmware now.

For most non-ODM vendors this change will have no effective change.