### PR TITLE
Store the upload vendor in the database directly

### DIFF
--- a/lvfs/firmware/routes.py
+++ b/lvfs/firmware/routes.py
@@ -18,7 +18,7 @@ from lvfs import app, db, ploader
 
 from lvfs.emails import send_email
 from lvfs.models import Firmware, Report, Client, FirmwareEvent, FirmwareLimit
-from lvfs.models import Remote, Vendor, AnalyticFirmware, Component, User
+from lvfs.models import Remote, Vendor, AnalyticFirmware, Component
 from lvfs.models import ComponentShard, ComponentShardChecksum
 from lvfs.models import _get_datestr_from_datetime
 from lvfs.util import _error_internal, admin_login_required
@@ -36,12 +36,9 @@ def route_firmware(state=None):
     """
     # pre-filter by user ID or vendor
     if g.user.check_acl('@analyst') or g.user.check_acl('@qa'):
-        subq = db.session.query(User.user_id).\
-                                filter(User.vendor_id == g.user.vendor.vendor_id).\
-                                subquery()
         stmt = db.session.query(Firmware).\
                     filter((Firmware.vendor_id == g.user.vendor.vendor_id) | \
-                           (Firmware.user_id.in_(subq)))
+                           (Firmware.vendor_odm_id == g.user.vendor.vendor_id))
     else:
         stmt = db.session.query(Firmware).\
                     filter(Firmware.user_id == g.user.user_id)

--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -466,6 +466,7 @@ class Vendor(db.Model):
                                     foreign_keys=[Affiliation.vendor_id_odm],
                                     back_populates="vendor")
     fws = relationship("Firmware",
+                       foreign_keys='[Firmware.vendor_id]',
                        cascade='all,delete-orphan')
     mdrefs = relationship('ComponentRef',
                           foreign_keys='[ComponentRef.vendor_id_partner]',
@@ -2004,6 +2005,7 @@ class Firmware(db.Model):
     failure_minimum = Column(Integer, default=0)
     failure_percentage = Column(Integer, default=0)
     _do_not_track = Column('do_not_track', Boolean, default=False)
+    vendor_odm_id = Column(Integer, ForeignKey('vendors.vendor_id'), nullable=False, index=True)
 
     mds = relationship("Component",
                        back_populates="fw",
@@ -2031,14 +2033,9 @@ class Firmware(db.Model):
                              cascade='all,delete-orphan')
 
     vendor = relationship('Vendor', foreign_keys=[vendor_id])
+    vendor_odm = relationship('Vendor', foreign_keys=[vendor_odm_id])
     user = relationship('User', foreign_keys=[user_id])
     remote = relationship('Remote', foreign_keys=[remote_id], lazy='joined')
-
-    @property
-    def vendor_odm(self):
-        if not self.user:
-            return None
-        return self.user.vendor
 
     @property
     def target_duration(self):

--- a/lvfs/upload/routes.py
+++ b/lvfs/upload/routes.py
@@ -219,6 +219,7 @@ def _upload_firmware():
     target = request.form['target']
     fw = ufile.fw
     fw.vendor = vendor
+    fw.vendor_odm = g.user.vendor
     fw.user = g.user
     fw.addr = _get_client_address()
     fw.remote = remote

--- a/migrations/versions/79fd156f0f48_firmware_vendor_odm_id_nonnull.py
+++ b/migrations/versions/79fd156f0f48_firmware_vendor_odm_id_nonnull.py
@@ -1,0 +1,30 @@
+"""
+
+Revision ID: 79fd156f0f48
+Revises: bf6316b24565
+Create Date: 2020-04-22 15:37:44.972630
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '79fd156f0f48'
+down_revision = 'bf6316b24565'
+
+from alembic import op
+import sqlalchemy as sa
+
+from lvfs import db
+from lvfs.models import Firmware
+
+def upgrade():
+    for fw in db.session.query(Firmware):
+        fw.vendor_odm = fw.user.vendor
+    db.session.commit()
+    op.alter_column('firmware', 'vendor_odm_id',
+               existing_type=sa.INTEGER(),
+               nullable=False)
+
+def downgrade():
+    op.alter_column('firmware', 'vendor_odm_id',
+               existing_type=sa.INTEGER(),
+               nullable=True)

--- a/migrations/versions/bf6316b24565_firmware_vendor_odm_id.py
+++ b/migrations/versions/bf6316b24565_firmware_vendor_odm_id.py
@@ -1,0 +1,26 @@
+"""
+
+Revision ID: bf6316b24565
+Revises: 6e1c3e4cfe3c
+Create Date: 2020-04-22 15:16:59.941379
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'bf6316b24565'
+down_revision = '6e1c3e4cfe3c'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('firmware', sa.Column('vendor_odm_id', sa.Integer(), nullable=True))
+    op.create_index(op.f('ix_firmware_vendor_odm_id'), 'firmware', ['vendor_odm_id'], unique=False)
+    op.create_foreign_key(None, 'firmware', 'vendors', ['vendor_odm_id'], ['vendor_id'])
+
+
+def downgrade():
+    op.drop_constraint(None, 'firmware', type_='foreignkey')
+    op.drop_index(op.f('ix_firmware_vendor_odm_id'), table_name='firmware')
+    op.drop_column('firmware', 'vendor_odm_id')


### PR DESCRIPTION
Doing a subsquery of all users in a vendor group takes a lot of time in large
vendors like Dell and Lenovo.

One extra indexed integer will speed things up a lot!