### PR TITLE
Allow clients to upload anonymous HSI attrs

### DIFF
--- a/lvfs/__init__.py
+++ b/lvfs/__init__.py
@@ -56,6 +56,7 @@ from lvfs.categories.routes import bp_categories
 from lvfs.claims.routes import bp_claims
 from lvfs.components.routes import bp_components
 from lvfs.devices.routes import bp_devices
+from lvfs.hsireports.routes import bp_hsireports
 from lvfs.mdsync.routes import bp_mdsync
 from lvfs.docs.routes import bp_docs
 from lvfs.firmware.routes import bp_firmware
@@ -99,6 +100,7 @@ app.register_blueprint(bp_upload, url_prefix='/lvfs/upload')
 app.register_blueprint(bp_users, url_prefix='/lvfs/users')
 app.register_blueprint(bp_vendors, url_prefix='/lvfs/vendors')
 app.register_blueprint(bp_verfmts, url_prefix='/lvfs/verfmts')
+app.register_blueprint(bp_hsireports, url_prefix='/lvfs/hsireports')
 
 def _set_up_notify_server_error():
     from lvfs.models import User, UserAction

--- a/lvfs/hsireports/routes.py
+++ b/lvfs/hsireports/routes.py
@@ -1,0 +1,246 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2018-2020 Richard Hughes <richard@hughsie.com>
+#
+# SPDX-License-Identifier: GPL-2.0+
+
+import json
+
+from flask import Blueprint, request, url_for, redirect, flash, Response, render_template
+from flask_login import login_required
+
+from lvfs import db, csrf
+
+from lvfs.hash import _is_sha256
+from lvfs.models import HsiReport, HsiReportAttr
+from lvfs.util import admin_login_required, _pkcs7_signature_info
+from lvfs.util import _json_success, _json_error
+
+bp_hsireports = Blueprint('hsireports', __name__, template_folder='templates')
+
+@bp_hsireports.route('/')
+@login_required
+@admin_login_required
+def route_list():
+    rpts = db.session.query(HsiReport)\
+                     .order_by(HsiReport.timestamp.desc())\
+                     .limit(100).all()
+    return render_template('hsireport-list.html',
+                           category='admin',
+                           rpts_filter=None,
+                           rpts=rpts)
+
+@bp_hsireports.route('/vendor/<host_vendor>')
+@login_required
+@admin_login_required
+def route_vendor_show(host_vendor):
+    rpts = db.session.query(HsiReport)\
+                     .filter(HsiReport.host_vendor == host_vendor)\
+                     .order_by(HsiReport.timestamp.desc())\
+                     .limit(100).all()
+    return render_template('hsireport-list.html',
+                           category='admin',
+                           rpts_filter=host_vendor,
+                           rpts=rpts)
+
+@bp_hsireports.route('/product/<host_product>')
+@login_required
+@admin_login_required
+def route_product_show(host_product):
+    rpts = db.session.query(HsiReport)\
+                     .filter(HsiReport.host_product == host_product)\
+                     .order_by(HsiReport.timestamp.desc())\
+                     .limit(100).all()
+    return render_template('hsireport-list.html',
+                           category='admin',
+                           rpts_filter=host_product,
+                           rpts=rpts)
+
+@bp_hsireports.route('/sku/<host_sku>')
+@login_required
+@admin_login_required
+def route_sku_show(host_sku):
+    rpts = db.session.query(HsiReport)\
+                     .filter(HsiReport.host_sku == host_sku)\
+                     .order_by(HsiReport.timestamp.desc())\
+                     .limit(100).all()
+    return render_template('hsireport-list.html',
+                           category='admin',
+                           rpts_filter=host_sku,
+                           rpts=rpts)
+
+@bp_hsireports.route('/family/<host_family>')
+@login_required
+@admin_login_required
+def route_family_show(host_family):
+    rpts = db.session.query(HsiReport)\
+                     .filter(HsiReport.host_family == host_family)\
+                     .order_by(HsiReport.timestamp.desc())\
+                     .limit(100).all()
+    return render_template('hsireport-list.html',
+                           category='admin',
+                           rpts_filter=host_family,
+                           rpts=rpts)
+
+@bp_hsireports.route('/<int:hsi_report_id>')
+@login_required
+def route_show(hsi_report_id):
+    rpt = db.session.query(HsiReport).filter(HsiReport.hsi_report_id == hsi_report_id).first()
+    if not rpt:
+        flash('HsiReport does not exist', 'danger')
+        return redirect(url_for('main.route_dashboard'))
+    # security check
+    if not rpt.check_acl('@view'):
+        flash('Permission denied: Unable to view report', 'danger')
+        return redirect(url_for('main.route_dashboard'))
+    return render_template('hsireport-details.html',
+                           category='admin',
+                           rpt=rpt)
+
+@bp_hsireports.route('/<int:hsi_report_id>/raw')
+@login_required
+def route_view(hsi_report_id):
+    rpt = db.session.query(HsiReport).filter(HsiReport.hsi_report_id == hsi_report_id).first()
+    if not rpt:
+        return _json_error('HsiReport does not exist')
+    # security check
+    if not rpt.check_acl('@view'):
+        flash('Permission denied: Unable to view report', 'danger')
+        return redirect(url_for('main.route_dashboard'))
+    return Response(response=str(rpt.to_kvs()),
+                    status=400, \
+                    mimetype="application/json")
+
+@bp_hsireports.route('/<int:hsi_report_id>/delete')
+@login_required
+def route_delete(hsi_report_id):
+    rpt = db.session.query(HsiReport).filter(HsiReport.hsi_report_id == hsi_report_id).first()
+    if not rpt:
+        flash('No report found!', 'danger')
+        return redirect(url_for('analytics.route_hsireports'))
+    # security check
+    if not rpt.check_acl('@delete'):
+        flash('Permission denied: Unable to delete report', 'danger')
+        return redirect(url_for('hsireports.route_show', hsi_report_id=hsi_report_id))
+    db.session.delete(rpt)
+    db.session.commit()
+    flash('Deleted report', 'info')
+    return redirect(url_for('analytics.route_hsireports'))
+
+@bp_hsireports.route('/upload', methods=['POST'])
+@csrf.exempt
+def route_report():
+    """ Upload a report """
+
+    # only accept form data
+    if request.method != 'POST':
+        return _json_error('only POST supported')
+
+    # parse both content types, either application/json or multipart/form-data
+    signature = None
+    if request.data:
+        payload = request.data.decode('utf8')
+    elif request.form:
+        data = request.form.to_dict()
+        if 'payload' not in data:
+            return _json_error('No payload in multipart/form-data')
+        payload = data['payload']
+        if 'signature' in data:
+            signature = data['signature']
+    else:
+        return _json_error('No data')
+
+    # find user and verify
+    if signature:
+        try:
+            info = _pkcs7_signature_info(signature, check_rc=False)
+        except IOError as e:
+            return _json_error('Signature invalid: %s' % str(e))
+        if 'serial' not in info:
+            return _json_error('Signature invalid, no signature')
+
+    # parse JSON data
+    try:
+        item = json.loads(payload)
+    except ValueError as e:
+        return _json_error('No JSON object could be decoded: ' + str(e))
+
+    # check we got enough data
+    for key in ['ReportVersion', 'MachineId', 'Metadata']:
+        if not key in item:
+            return _json_error('invalid data, expected %s' % key)
+        if item[key] is None:
+            return _json_error('missing data, expected %s' % key)
+
+    # parse only this version
+    if item['ReportVersion'] != 2:
+        return _json_error('report version not supported')
+
+    # add each firmware report
+    machine_id = item['MachineId']
+    if not _is_sha256(machine_id):
+        return _json_error('MachineId invalid, expected SHA256')
+    hsireports = item.get('HsiReports', [])
+    sec_attrs = item.get('SecurityAttributes', [])
+    if not hsireports and not sec_attrs:
+        return _json_error('no hsireports included')
+    metadata = item['Metadata']
+    if not metadata:
+        return _json_error('no metadata included')
+
+    if sec_attrs:
+
+        # required metadata for this report type
+        for key in ['HostProduct', 'HostFamily', 'HostVendor', 'HostSku']:
+            if not key in metadata:
+                return _json_error('invalid data, expected %s' % key)
+            if metadata[key] is None:
+                return _json_error('missing data, expected %s' % key)
+
+        # check attrs
+        for sec_attr in sec_attrs:
+            for key in ['AppstreamId', 'HsiResult']:
+                if not key in sec_attr:
+                    return _json_error('invalid data, expected %s' % key)
+                if sec_attr[key] is None:
+                    return _json_error('missing data, expected %s' % key)
+
+        # update any old report
+        rpt = db.session.query(HsiReport)\
+                        .filter(HsiReport.machine_id == machine_id).first()
+        if rpt:
+            db.session.delete(rpt)
+
+        # construct a single string
+        distro = '{} {} ({})'.format(metadata.get('DistroId', 'Unknown'),
+                                     metadata.get('DistroVersion', 'Unknown'),
+                                     metadata.get('DistroVariant', 'Unknown'))
+
+        # save a new report in the database
+        host_security_parts = metadata['HostSecurityId'].split(' ')
+        rpt = HsiReport(payload=payload,          # in case we want to extract
+                        signature=signature,      # if we want to match the user
+                        machine_id=machine_id,
+                        distro=distro,
+                        kernel_cmdline=metadata.get('KernelCmdline'),
+                        kernel_version=metadata.get('KernelVersion'),
+                        host_product=metadata['HostProduct'],
+                        host_vendor=metadata['HostVendor'],
+                        host_family=metadata['HostFamily'],
+                        host_sku=metadata['HostSku'],
+                        host_security_id=host_security_parts[0],
+                        host_security_version=host_security_parts[1][2:-1])
+        for sec_attr in sec_attrs:
+            flags = sec_attr.get('Flags', [])
+            attr = HsiReportAttr(appstream_id=sec_attr['AppstreamId'],
+                                 hsi_result=sec_attr['HsiResult'],
+                                 is_runtime='runtime-issue' in flags,
+                                 is_success='success' in flags,
+                                 is_obsoleted='obsoleted' in flags)
+            rpt.attrs.append(attr)
+        db.session.add(rpt)
+
+    # all done
+    db.session.commit()
+    return _json_success()

--- a/lvfs/hsireports/routes_test.py
+++ b/lvfs/hsireports/routes_test.py
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2018-2019 Richard Hughes <richard@hughsie.com>
+#
+# SPDX-License-Identifier: GPL-2.0+
+#
+# pylint: disable=wrong-import-position,singleton-comparison
+
+import os
+import sys
+import unittest
+
+sys.path.append(os.path.realpath('.'))
+
+from lvfs.testcase import LvfsTestCase
+
+class LocalTestCase(LvfsTestCase):
+
+    def test_hsireports(self):
+
+        # upload a firmware that can receive a report
+        self.login()
+        self.upload(target='testing')
+
+        # send empty
+        rv = self.app.post('/lvfs/hsireports/upload')
+        assert b'No data' in rv.data, rv.data
+
+        # self less than what we need
+        rv = self.app.post('/lvfs/hsireports/upload', data='{"MachineId" : "abc"}')
+        assert b'invalid data, expected ReportVersion' in rv.data, rv.data
+
+if __name__ == '__main__':
+    unittest.main()

--- a/lvfs/hsireports/templates/hsireport-details.html
+++ b/lvfs/hsireports/templates/hsireport-details.html
@@ -1,0 +1,106 @@
+{% extends "default.html" %}
+{% block title %}HSI Report {{rpt.hsi_report_id}}{% endblock %}
+
+{% block nav %}{% include 'hsireport-nav.html' %}{% endblock %}
+
+{% block content %}
+<div class="card-deck">
+<div class="card">
+  <div class="card-body">
+  <h2 class="card-title">HSI Report {{rpt.hsi_report_id}}</h2>
+<table class="table card-text">
+  <tr class="row table-borderless">
+    <th class="col col-3">Submitted</th>
+    <td class="col"><code>{{rpt.timestamp.strftime('%F %T')}}</code></td>
+  </tr>
+  <tr class="row table-borderless">
+    <th class="col col-3">HSI</th>
+    <td class="col"><code>{{rpt.host_security_id}} {{rpt.host_security_version}}</code></td>
+  </tr>
+{% if rpt.kernel_version %}
+  <tr class="row table-borderless">
+    <th class="col col-3">Kernel Version</th>
+    <td class="col"><code>{{rpt.kernel_version}}</code></td>
+  </tr>
+{% endif %}
+{% if rpt.kernel_cmdline %}
+  <tr class="row table-borderless">
+    <th class="col col-3">Kernel Commandline</th>
+    <td class="col"><code>{{rpt.kernel_cmdline}}</code></td>
+  </tr>
+{% endif %}
+{% if rpt.distro %}
+  <tr class="row table-borderless">
+    <th class="col col-3">Distribution</th>
+    <td class="col"><code>{{rpt.distro}}</code></td>
+  </tr>
+{% endif %}
+{% if rpt.user %}
+  <tr class="row table-borderless">
+    <th class="col col-3">User</th>
+    <td class="col"><code>{{rpt.user.display_name}}</code></td>
+  </tr>
+{% endif %}
+</table>
+  </div>
+</div>
+<div class="card">
+  <div class="card-body">
+  <h2 class="card-title">Device</h2>
+<table class="table card-text">
+  <tr class="row table-borderless">
+    <th class="col col-3">Machine</th>
+    <td class="col text-truncate"><code>{{rpt.machine_id}}</code></td>
+  </tr>
+  <tr class="row table-borderless">
+    <th class="col col-3">Vendor</th>
+    <td class="col"><code>{{rpt.host_vendor}}</code></td>
+  </tr>
+  <tr class="row table-borderless">
+    <th class="col col-3">Product</th>
+    <td class="col"><code>{{rpt.host_product}}</code></td>
+  </tr>
+  <tr class="row table-borderless">
+    <th class="col col-3">Family</th>
+    <td class="col"><code>{{rpt.host_family}}</code></td>
+  </tr>
+  <tr class="row table-borderless">
+    <th class="col col-3">SKU</th>
+    <td class="col"><code>{{rpt.host_sku}}</code></td>
+  </tr>
+</table>
+  </div>
+</div>
+</div>
+
+<div class="card mt-3">
+  <div class="card-body">
+  <h2 class="card-title">HSI Attributes</h2>
+<table class="table card-text">
+  <tr class="row table-borderless">
+    <th class="col">AppStream ID</th>
+    <th class="col">Result</th>
+  </tr>
+{% for rattr in rpt.attrs|sort(attribute='key') %}
+  <tr class="row">
+    <td class="col"><code>{{rattr.appstream_id}}</code></td>
+    <td class="col">
+{% if rattr.is_success %}
+      <span class="fas fa-check-circle fs-1 text-success mr-2"></span>
+{% else %}
+      <span class="fas fa-times-circle fs-1 text-danger mr-2"></span>
+{% endif %}
+      <code>{{rattr.hsi_result}}</code>
+{% if rattr.is_runtime %}
+      (runtime)
+{% endif %}
+{% if rattr.is_obsoleted %}
+      (obsoleted)
+{% endif %}
+    </td>
+  </tr>
+{% endfor %}
+</table>
+  </div>
+</div>
+{% endblock %}

--- a/lvfs/hsireports/templates/hsireport-list.html
+++ b/lvfs/hsireports/templates/hsireport-list.html
@@ -1,0 +1,49 @@
+{% extends "default.html" %}
+{% block title %}HSI Reports{% endblock %}
+
+{% block nav %}
+{% if rpts_filter %}
+{% include 'hsireport-nav.html' %}
+{% endif %}
+{% endblock %}
+
+{% block content %}
+<div class="card">
+  <div class="card-body">
+  <h2 class="card-title">
+    HSI Reports
+{% if rpts_filter %}
+    ({{rpts_filter}})
+{% endif %}
+  </h2>
+<table class="table">
+  <tr class="row table-borderless">
+    <th class="col col-sm-3">Timestamp</th>
+    <th class="col col-sm-5">Model</th>
+    <th class="col col-sm-2">HSI</th>
+    <th class="col col-sm-2"></th>
+  </tr>
+{% for rpt in rpts %}
+  <tr class="row">
+    <td class="col col-sm-3">{{rpt.timestamp.strftime('%F %T')}}</td>
+    <td class="col col-sm-5">
+      <a href="{{url_for('hsireports.route_vendor_show', host_vendor=rpt.host_vendor)}}">{{rpt.host_vendor}}</a>
+{% if rpt.host_vendor == 'LENOVO' %}
+      <a href="{{url_for('hsireports.route_family_show', host_family=rpt.host_family)}}">{{rpt.host_family}}</a>
+      (<code><a href="{{url_for('hsireports.route_product_show', host_product=rpt.host_product)}}">{{rpt.host_product}}</a></code>)
+{% else %}
+      <a href="{{url_for('hsireports.route_product_show', host_product=rpt.host_product)}}">{{rpt.host_product}}</a>
+      (<code><a href="{{url_for('hsireports.route_sku_show', host_sku=rpt.host_sku)}}">{{rpt.host_sku}}</a></code>)
+{% endif %}
+    </td>
+    <td class="col col-sm-2"><code>{{rpt.host_security_id}}</code></td>
+    <td class="col col-sm-2">
+      <a class="btn btn-info btn-block"
+         href="{{url_for('hsireports.route_show', hsi_report_id=rpt.hsi_report_id)}}">Info</a>
+    </td>
+  </tr>
+{% endfor %}
+</table>
+  </div>
+</div>
+{% endblock %}

--- a/lvfs/hsireports/templates/hsireport-nav.html
+++ b/lvfs/hsireports/templates/hsireport-nav.html
@@ -1,0 +1,8 @@
+<nav class="row">
+  <div class="col col-sm-1 btn-group mb-3">
+    <a class="btn btn-falcon-default mr-sm-3"
+      href="{{url_for('hsireports.route_list')}}">
+      <span class="fas fa-arrow-left"></span>
+    </a>
+  </div>
+</nav>

--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -2474,6 +2474,65 @@ class Issue(db.Model):
     def __repr__(self):
         return "Issue object %s" % self.url
 
+class HsiReportAttr(db.Model):
+    __tablename__ = 'hsi_report_attrs'
+
+    report_attr_id = Column(Integer, primary_key=True)
+    hsi_report_id = Column(Integer, ForeignKey('hsi_reports.hsi_report_id'), nullable=False, index=True)
+    appstream_id = Column(Text, nullable=False)
+    hsi_result = Column(Text, default=None)
+    is_success = Column(Boolean, default=False)
+    is_runtime = Column(Boolean, default=False)
+    is_obsoleted = Column(Boolean, default=False)
+
+    report = relationship("HsiReport", back_populates="attrs")
+
+    def __repr__(self):
+        return "HsiReportAttr object %s=%s" % (self.key, self.value)
+
+class HsiReport(db.Model):
+
+    __tablename__ = 'hsi_reports'
+
+    hsi_report_id = Column(Integer, primary_key=True)
+    timestamp = Column(DateTime, nullable=False, default=datetime.datetime.utcnow)
+    payload = Column(Text, nullable=False)
+    signature = Column(Text, default=None)
+    machine_id = Column(String(64), nullable=False)
+    distro = Column(Text, default=None)
+    kernel_cmdline = Column(Text, default=None)
+    kernel_version = Column(Text, default=None)
+    host_product = Column(Text, default=None, index=True)
+    host_vendor = Column(Text, default=None, index=True)
+    host_family = Column(Text, default=None, index=True)
+    host_sku = Column(Text, default=None, index=True)
+    host_security_id = Column(Text, nullable=False)
+    host_security_version = Column(Text, nullable=False)
+    user_id = Column(Integer, ForeignKey('users.user_id'), default=None)
+
+    user = relationship('User', foreign_keys=[user_id])
+    attrs = relationship("HsiReportAttr",
+                         back_populates="report",
+                         cascade='all,delete-orphan')
+
+    def check_acl(self, action, user=None):
+
+        # fall back
+        if not user:
+            user = g.user
+        if user.check_acl('@admin'):
+            return True
+
+        # depends on the action requested
+        if action == '@delete':
+            return False
+        if action == '@view':
+            return True
+        raise NotImplementedError('unknown security check action: %s:%s' % (self, action))
+
+    def __repr__(self):
+        return "HsiReport object {}".format(self.hsi_report_id)
+
 class ReportAttribute(db.Model):
     __tablename__ = 'report_attributes'
 

--- a/lvfs/templates/private.html
+++ b/lvfs/templates/private.html
@@ -158,6 +158,9 @@
             <li class="nav-item {{'active' if request.url_rule.endpoint == 'agreements.route_list'}}">
               <a class="nav-link" href="{{url_for('agreements.route_list')}}">Agreements</a>
             </li>
+            <li class="nav-item {{'active' if request.url_rule.endpoint == 'hsireports.route_list'}}">
+              <a class="nav-link" href="{{url_for('hsireports.route_list')}}">HSI Reports</a>
+            </li>
           </ul>
         </li>
         <li class="nav-item">

--- a/migrations/versions/3dc586299daf_hsi_reports.py
+++ b/migrations/versions/3dc586299daf_hsi_reports.py
@@ -1,0 +1,62 @@
+"""
+
+Revision ID: 3dc586299daf
+Revises: 0956dab5aa94
+Create Date: 2020-05-19 12:57:06.200229
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3dc586299daf'
+down_revision = '0956dab5aa94'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('hsi_reports',
+    sa.Column('hsi_report_id', sa.Integer(), nullable=False),
+    sa.Column('timestamp', sa.DateTime(), nullable=False),
+    sa.Column('payload', sa.Text(), nullable=False),
+    sa.Column('signature', sa.Text(), nullable=True),
+    sa.Column('machine_id', sa.String(length=64), nullable=False),
+    sa.Column('distro', sa.Text(), nullable=True),
+    sa.Column('kernel_cmdline', sa.Text(), nullable=True),
+    sa.Column('kernel_version', sa.Text(), nullable=True),
+    sa.Column('host_product', sa.Text(), nullable=True),
+    sa.Column('host_vendor', sa.Text(), nullable=True),
+    sa.Column('host_family', sa.Text(), nullable=True),
+    sa.Column('host_sku', sa.Text(), nullable=True),
+    sa.Column('host_security_id', sa.Text(), nullable=False),
+    sa.Column('host_security_version', sa.Text(), nullable=False),
+    sa.Column('user_id', sa.Integer(), nullable=True),
+    sa.ForeignKeyConstraint(['user_id'], ['users.user_id'], ),
+    sa.PrimaryKeyConstraint('hsi_report_id')
+    )
+    op.create_index(op.f('ix_hsi_reports_host_family'), 'hsi_reports', ['host_family'], unique=False)
+    op.create_index(op.f('ix_hsi_reports_host_sku'), 'hsi_reports', ['host_sku'], unique=False)
+    op.create_index(op.f('ix_hsi_reports_host_product'), 'hsi_reports', ['host_product'], unique=False)
+    op.create_index(op.f('ix_hsi_reports_host_vendor'), 'hsi_reports', ['host_vendor'], unique=False)
+    op.create_table('hsi_report_attrs',
+    sa.Column('report_attr_id', sa.Integer(), nullable=False),
+    sa.Column('hsi_report_id', sa.Integer(), nullable=False),
+    sa.Column('appstream_id', sa.Text(), nullable=False),
+    sa.Column('hsi_result', sa.Text(), nullable=True),
+    sa.Column('is_success', sa.Boolean(), nullable=True),
+    sa.Column('is_runtime', sa.Boolean(), nullable=True),
+    sa.Column('is_obsoleted', sa.Boolean(), nullable=True),
+    sa.ForeignKeyConstraint(['hsi_report_id'], ['hsi_reports.hsi_report_id'], ),
+    sa.PrimaryKeyConstraint('report_attr_id')
+    )
+    op.create_index(op.f('ix_hsi_report_attrs_hsi_report_id'), 'hsi_report_attrs', ['hsi_report_id'], unique=False)
+
+
+def downgrade():
+    op.drop_index(op.f('ix_hsi_report_attrs_hsi_report_id'), table_name='hsi_report_attrs')
+    op.drop_table('hsi_report_attrs')
+    op.drop_index(op.f('ix_hsi_reports_host_vendor'), table_name='hsi_reports')
+    op.drop_index(op.f('ix_hsi_reports_host_product'), table_name='hsi_reports')
+    op.drop_index(op.f('ix_hsi_reports_host_family'), table_name='hsi_reports')
+    op.drop_index(op.f('ix_hsi_reports_host_sku'), table_name='hsi_reports')
+    op.drop_table('hsi_reports')


### PR DESCRIPTION
At the moment we just show the last 100 HSI reports, but with more data it can
be correlated back to the Firmware() and/or Vendor() objects so we can show a
per-model overview of the submitted HSI values.

This is intended to influence customer purchasing decisions.