### PR TITLE
Improve the report query speed by several orders of magnitude

### DIFF
--- a/lvfs/analytics/templates/analytics-reports.html
+++ b/lvfs/analytics/templates/analytics-reports.html
@@ -22,11 +22,18 @@
     <code class="float-right">{{format_humanize_naturaltime(r.timestamp)}}</code>
   </h2>
   <div class="card-body">
-    <p class="card-text">
-      <code>{{r.to_kvs()}}</code>
-    </p>
+    <table class="table">
+{% for attr in r.attributes|sort %}
+      <tr class="row table-borderless">
+        <th class="col col-sm-4">{{attr.key}}</th>
+        <td class="col col-sm-8"><code>{{attr.value}}</code></td>
+      </tr>
+{% endfor %}
+    </table>
     <a class="card-link btn btn-info" href="{{url_for('firmware.route_show', firmware_id=r.fw.firmware_id)}}">Details</a>
-    <a class="card-link btn btn-danger float-right" href="{{url_for('reports.route_delete', report_id=r.report_id)}}">Delete</a>
+{% if g.user.check_acl('@admin') %}
+    <a class="card-link btn btn-danger" href="{{url_for('reports.route_delete', report_id=r.report_id)}}">Delete</a>
+{% endif %}
   </div>
 </div>
 {% endfor %}

--- a/lvfs/firmware/templates/firmware-analytics-reports.html
+++ b/lvfs/firmware/templates/firmware-analytics-reports.html
@@ -10,12 +10,18 @@
 {% for r in reports %}
 <div class="card mb-3">
   <h2 class="card-header card-title list-group-item-{{r.color}}">
-    {{r.timestamp}}
+    {{r.fw.md_prio.developer_name_display}} {{r.fw.names|join(' & ')}}
+    <code class="float-right">{{format_humanize_naturaltime(r.timestamp)}}</code>
   </h2>
   <div class="card-body">
-    <p class="card-text">
-      <code>{{r.to_kvs()}}</code>
-    </p>
+    <table class="table">
+{% for attr in r.attributes|sort %}
+      <tr class="row table-borderless">
+        <th class="col col-sm-4">{{attr.key}}</th>
+        <td class="col col-sm-8"><code>{{attr.value}}</code></td>
+      </tr>
+{% endfor %}
+    </table>
 {% if g.user.check_acl('@admin') %}
     <a class="card-link btn btn-danger" href="{{url_for('reports.route_delete', report_id=r.report_id)}}">Delete</a>
 {% endif %}

--- a/lvfs/issues/templates/issue-reports.html
+++ b/lvfs/issues/templates/issue-reports.html
@@ -12,9 +12,21 @@
 
 {% for r in reports %}
 <div class="card mt-3">
+  <h2 class="card-header card-title list-group-item-{{r.color}}">
+    {{r.fw.md_prio.developer_name_display}} {{r.fw.names|join(' & ')}}
+    <code class="float-right">{{format_humanize_naturaltime(r.timestamp)}}</code>
+  </h2>
   <div class="card-body">
-    <h2 class="card-title">{{r.timestamp}}</h2>
-    <code class="card-text">{{r.to_kvs()}}</code>
+    <table class="table">
+{% for attr in r.attributes|sort %}
+      <tr class="row table-borderless">
+        <th class="col col-sm-4">{{attr.key}}</th>
+        <td class="col col-sm-8"><code>{{attr.value}}</code></td>
+      </tr>
+{% endfor %}
+    </table>
+    <a class="card-link btn btn-info" href="{{url_for('firmware.route_show', firmware_id=r.fw.firmware_id)}}">Details</a>
+    <a class="card-link btn btn-danger float-right" href="{{url_for('reports.route_delete', report_id=r.report_id)}}">Delete</a>
   </div>
 </div>
 {% endfor %}

--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -2551,6 +2551,9 @@ class ReportAttribute(db.Model):
 
     report = relationship("Report", back_populates="attributes")
 
+    def __lt__(self, other):
+        return self.key < other.key
+
     def __repr__(self):
         return "ReportAttribute object %s=%s" % (self.key, self.value)
 
@@ -2587,33 +2590,6 @@ class Report(db.Model):
         if self.state == 4:
             return 'info'
         return 'danger'
-
-    def to_flat_dict(self):
-        data = {}
-        if self.state == 1:
-            data['UpdateState'] = 'pending'
-        elif self.state == 2:
-            data['UpdateState'] = 'success'
-        elif self.state == 3:
-            data['UpdateState'] = 'failed'
-        elif self.state == 4:
-            data['UpdateState'] = 'needs-reboot'
-        else:
-            data['UpdateState'] = 'unknown'
-        if self.machine_id:
-            data['MachineId'] = self.machine_id
-        if self.firmware_id:
-            data['FirmwareId'] = self.firmware_id
-        for attr in self.attributes:
-            data[attr.key] = attr.value
-        return data
-
-    def to_kvs(self):
-        flat_dict = self.to_flat_dict()
-        kv_array = []
-        for key in flat_dict:
-            kv_array.append('%s=%s' % (key, flat_dict[key]))
-        return ', '.join(sorted(kv_array))
 
     def check_acl(self, action, user=None):
 

--- a/lvfs/reports/routes_test.py
+++ b/lvfs/reports/routes_test.py
@@ -76,7 +76,7 @@ class LocalTestCase(LvfsTestCase):
 
         # check the saved report
         rv = self.app.get('/lvfs/reports/1')
-        assert b'UpdateState=success' in rv.data, rv.data
+        assert b'UpdateState": "success' in rv.data, rv.data
 
         # download the firmware at least once
         self._download_firmware()


### PR DESCRIPTION
Use stacked subqueries to do all the heavy lifting on the database server. It
turns out databases are good at doing database things.

This speeds up showing matching reports from over 60 seconds in the worst case,
(often timing out the uwsgi socket) to ~150ms which is more than acceptable.