### PR TITLE
Export the success confidence to the mdsync vendor

### DIFF
--- a/lvfs/mdsync/routes.py
+++ b/lvfs/mdsync/routes.py
@@ -34,6 +34,7 @@ def _md_to_mdsync_dict(md):
             obj['changelog_url'] = md.details_url
         if md.fw.success:
             obj['success'] = md.fw.success
+            obj['success_confidence'] = md.fw.success_confidence
     return obj
 
 def _mds_to_mdsync_dict(mds):

--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -2079,6 +2079,15 @@ class Firmware(db.Model):
         return (self.report_success_cnt * 100) / total
 
     @property
+    def success_confidence(self):
+        total = self.report_failure_cnt + self.report_success_cnt + self.report_issue_cnt
+        if total > 1000:
+            return 'high'
+        if total > 100:
+            return 'medium'
+        return 'low'
+
+    @property
     def filename_absolute(self):
         if self.is_deleted:
             return os.path.join('/deleted', self.filename)


### PR DESCRIPTION
The actual number of reports (which will be related to the number of firmware
downloads) is a private stat we can't share with anyone; however it would be
really useful to know the order of magnitude of reports. This way 50% failure
with just two reports would not trigger any alarms.

The high/medium/low states are granular enough to be useful, but should not
leak numbers that OEMs might consider private.