### PR TITLE
Run any pending tests every 60 minutes

### DIFF
--- a/lvfs/components/routes.py
+++ b/lvfs/components/routes.py
@@ -186,6 +186,9 @@ def route_modify(component_id):
     # ensure the test has been added for the new firmware type
     ploader.ensure_test_for_fw(md.fw)
 
+    # sync everything we added
+    db.session.commit()
+
     # asynchronously run
     _async_test_run_for_firmware.apply_async(args=(md.fw.firmware_id,))
 

--- a/lvfs/firmware/routes.py
+++ b/lvfs/firmware/routes.py
@@ -291,6 +291,9 @@ def route_promote(firmware_id, target):
     # some tests only run when the firmware is in stable
     ploader.ensure_test_for_fw(fw)
 
+    # sync everything we added
+    db.session.commit()
+
     # asynchronously run
     _async_test_run_for_firmware.apply_async(args=(fw.firmware_id,))
 

--- a/lvfs/tests/utils.py
+++ b/lvfs/tests/utils.py
@@ -65,6 +65,15 @@ def _test_run_all(tests=None):
     # all done
     db.session.commit()
 
+@celery.task(max_retries=3, default_retry_delay=600, task_time_limit=3600)
+def _async_test_run_all():
+    tests = db.session.query(Test)\
+                      .filter(Test.started_ts == None)\
+                      .all()
+    if not tests:
+        return
+    _test_run_all(tests)
+
 @celery.task(max_retries=3, default_retry_delay=5, task_time_limit=600)
 def _async_test_run(test_id):
     tests = db.session.query(Test)\

--- a/lvfs/upload/routes.py
+++ b/lvfs/upload/routes.py
@@ -251,6 +251,9 @@ def _upload_firmware():
     # ensure the test has been added for the firmware type
     ploader.ensure_test_for_fw(fw)
 
+    # sync everything we added
+    db.session.commit()
+
     # asynchronously run
     _async_test_run_for_firmware.apply_async(args=(fw.firmware_id,))
 


### PR DESCRIPTION
Something isn't scheduling tests correctly, and until we work out what it is
run all pending tests on a timer.