### PR TITLE
Do not allow users requiring OAuth to use /lvfs/login

### DIFF
--- a/lvfs/main/routes.py
+++ b/lvfs/main/routes.py
@@ -373,6 +373,8 @@ def route_login():
         if not user:
             flash('Failed to log in: Incorrect username {}'.format(username), 'danger')
             return redirect(url_for('main.route_index'))
+        flash('Failed to log in: {} must use OAuth to login'.format(username), 'danger')
+        return redirect(url_for('main.route_index'))
 
     # check auth type
     if not user.auth_type or user.auth_type == 'disabled':


### PR DESCRIPTION
If we called /lvfs/login manually using curl, with a username that matched a
Vendor.oauth_domain_glob then we would create a user and the session would be
marked as logged in. Thankfully the schema check on the database for a missing
username saves us, resulting in a uwsgi stacktrace and a 'LVFS is unavailable'
error instead.

The missing code just informs the user that they have to use the *other*
button in the login screen, which I presume was the reason for the call to
`_create_user_for_oauth_username()` in the first place...

Spotted by Justin Steven <justin@justinsteven.com>, many thanks.