### PR TITLE
Use a non-predictable vendor icon filename

### DIFF
--- a/lvfs/vendors/routes.py
+++ b/lvfs/vendors/routes.py
@@ -26,6 +26,8 @@ from lvfs.metadata.utils import _async_regenerate_remote
 from lvfs.models import Vendor, Restriction, Namespace, User, Remote, Affiliation, AffiliationAction, Verfmt, Firmware
 from lvfs.util import _generate_password
 
+from .utils import _vendor_hash
+
 bp_vendors = Blueprint('vendors', __name__, template_folder='templates')
 
 def _count_vendor_fws_public(vendor, remote_name):
@@ -515,7 +517,8 @@ def route_upload(vendor_id):
 
     # write the pixmap
     buf = request.files['file'].read()
-    fn = os.path.join(app.config['UPLOAD_DIR'], 'vendor-%s.png' % vendor_id)
+    hmac_dig = _vendor_hash(vendor)
+    fn = os.path.join(app.config['UPLOAD_DIR'], 'vendor-{}.png'.format(hmac_dig))
     with open(fn, 'wb') as f:
         f.write(buf)
 

--- a/lvfs/vendors/utils.py
+++ b/lvfs/vendors/utils.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020 Richard Hughes <richard@hughsie.com>
+#
+# SPDX-License-Identifier: GPL-2.0+
+
+import hashlib
+import hmac
+
+from lvfs import app
+
+def _vendor_hash(vendor):
+    """ Generate a HMAC of the vendor name """
+    return hmac.new(key=app.config['SECRET_VENDOR_SALT'].encode(),
+                    msg=vendor.group_id.encode(),
+                    digestmod=hashlib.sha256).hexdigest()


### PR DESCRIPTION
Users could 'guess' vendors who are on the LVFS but not visible by incrementing
the integer vendor key and seeing the new logo.

Use a HMAC of the group ID and rename the existing logo files.

Spotted by Justin Steven <justin@justinsteven.com>, many thanks.