### PR TITLE
Do not store the client address in the database

### DIFF
--- a/lvfs/analytics/templates/analytics-clients.html
+++ b/lvfs/analytics/templates/analytics-clients.html
@@ -17,7 +17,7 @@
 <div class="card mb-3">
   <div class="card-body">
     <h2 class="card-title">{{c.fw.md_prio.name_with_category}}</code></h2>
-    <p class="card-text">{{c.timestamp.strftime('%F %T')}} &mdash; from <code>{{c.addr|truncate(9, False, '…')}}</code></p>
+    <p class="card-text">{{c.timestamp.strftime('%F %T')}}</p>
     <p class="card-text"><code>{{c.user_agent}}</code></p>
     <a class="card-link" href="{{url_for('firmware.route_show', firmware_id=c.fw.firmware_id)}}">Details</a>
   </div>

--- a/lvfs/dbutils.py
+++ b/lvfs/dbutils.py
@@ -56,7 +56,7 @@ def _make_fake_version():
                          random.randint(1, 254))
 
 def anonymize_db(db):
-    from .models import Vendor, Firmware, Client
+    from .models import Vendor, Firmware
 
     # get vendor display names
     vendor_names = []
@@ -176,11 +176,6 @@ def anonymize_db(db):
         fw.checksum_signed_sha256 = hashlib.sha256(os.urandom(4096)).hexdigest()
         fw.filename = fw.checksum_upload_sha256 + '-' + fw.vendor.group_id + '-' + \
                       _make_boring(fw.md_prio.name) + '-' + fw.version_display + '.cab'
-
-    # anonymize clients -- only do this on beefy hardware...
-    if 'FLASK_RANDOMIZE_CLIENTS' in os.environ:
-        for cl in db.session.query(Client):
-            cl.addr = hashlib.sha1(os.urandom(32)).hexdigest()
 
     # phew!
     db.session.commit()

--- a/lvfs/main/routes.py
+++ b/lvfs/main/routes.py
@@ -34,7 +34,6 @@ from lvfs.pluginloader import PluginError
 from lvfs.models import Firmware, Requirement, Vendor, Metric
 from lvfs.models import User, Client, Event, AnalyticVendor, Remote
 from lvfs.models import _get_datestr_from_datetime
-from lvfs.hash import _addr_hash
 from lvfs.util import _get_client_address, _get_settings, _xml_from_markdown, _get_chart_labels_days
 from lvfs.util import _event_log, _error_internal
 
@@ -144,8 +143,7 @@ def serveStaticResource(resource):
         # log the client request
         if not fw.do_not_track:
             datestr = _get_datestr_from_datetime(datetime.datetime.utcnow())
-            db.session.add(Client(addr=_addr_hash(_get_client_address()),
-                                  firmware_id=fw.firmware_id,
+            db.session.add(Client(firmware_id=fw.firmware_id,
                                   user_agent=user_agent,
                                   datestr=datestr))
 

--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -2375,7 +2375,6 @@ class Client(db.Model):
     id = Column(Integer, primary_key=True)
     timestamp = Column(DateTime, nullable=False, default=datetime.datetime.utcnow, index=True)
     datestr = Column(Integer, default=0, index=True)
-    addr = Column(String(40), nullable=False)
     firmware_id = Column(Integer, ForeignKey('firmware.firmware_id'), nullable=False, index=True)
     user_agent = Column(Text, default=None)
 

--- a/migrations/versions/9bc9ca984cda_remove_client_addr.py
+++ b/migrations/versions/9bc9ca984cda_remove_client_addr.py
@@ -1,0 +1,22 @@
+"""
+
+Revision ID: 9bc9ca984cda
+Revises: 3dc586299daf
+Create Date: 2020-06-15 15:33:14.591154
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '9bc9ca984cda'
+down_revision = '3dc586299daf'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.drop_column('clients', 'addr')
+
+
+def downgrade():
+    op.add_column('clients', sa.Column('addr', sa.VARCHAR(length=40), autoincrement=False, nullable=False))


### PR DESCRIPTION
We already use the recent nginx for abuse detection, and we don't seem to use
the hashed client address anywhere useful in the LVFS.

The SHA1 hash is not terribly secure (even salted) and removing PII we do not
actually use seems a sane thing to do.

Spotted by Justin Steven <justin@justinsteven.com>, many thanks.