### PR TITLE
Ensure that all archive filenames are valid for PULP

### DIFF
--- a/lvfs/upload/uploadedfile.py
+++ b/lvfs/upload/uploadedfile.py
@@ -22,7 +22,7 @@ from cabarchive import CabArchive, CabFile
 from infparser import InfParser
 
 from lvfs.models import Firmware, Component, ComponentIssue, Guid, Requirement, Checksum
-from lvfs.util import _validate_guid, _markdown_from_root
+from lvfs.util import _validate_guid, _markdown_from_root, _get_sanitized_basename
 
 class FileTooLarge(Exception):
     pass
@@ -645,7 +645,8 @@ class UploadedFile:
         self.fw.checksum_upload_sha1 = hashlib.sha1(data).hexdigest()
         self.fw.checksum_upload_sha256 = hashlib.sha256(data).hexdigest()
         if use_hashed_prefix:
-            self.fw.filename = self.fw.checksum_upload_sha256 + '-' + filename.replace('.zip', '.cab')
+            filename_safe = _get_sanitized_basename(filename)
+            self.fw.filename = self.fw.checksum_upload_sha256 + '-' + filename_safe.replace('.zip', '.cab')
         else:
             self.fw.filename = filename.replace('.zip', '.cab')
 

--- a/lvfs/util.py
+++ b/lvfs/util.py
@@ -242,6 +242,12 @@ def _get_absolute_path(fw):
         return os.path.join(app.config['RESTORE_DIR'], fw.filename)
     return os.path.join(app.config['DOWNLOAD_DIR'], fw.filename)
 
+def _get_sanitized_basename(basename):
+    basename_sane = basename.encode('ascii', 'ignore').decode('utf-8')
+    for key, value in [(',', '_')]:
+        basename_sane = basename_sane.replace(key, value)
+    return basename_sane
+
 def _get_shard_path(shard):
     from lvfs import app
     return os.path.join(app.config['SHARD_DIR'], str(shard.component_id), shard.name)


### PR DESCRIPTION
Pulp cannot deal with filenames with comma chars in the filename as it is used
for the PULP_MANIFEST delimiter. Changing pulp-server to use `.rsplit()` rather
then `.split()` on all supported deployments is somewhat unlikely at this point.

Also, ensure the filename is restricted to ASCII encoding, as mirror targets
might be on filesystems that do not handle all of UTF-8 correctly.

This affects exactly one firmware on the LVFS.