### PR TITLE
Update old link in devicelist.html

### DIFF
--- a/lvfs/devices/templates/devicelist.html
+++ b/lvfs/devices/templates/devicelist.html
@@ -44,7 +44,7 @@
       This list is automatically generated and will be updated when new firmware
       is added or existing firmware is made available.
       For information about what vendors have been contacted about the LVFS,
-      please see the <a href="/vendorlist">vendor engagement list</a>.
+      please see the <a href="/lvfs/vendors/">vendor engagement list</a>.
     </p>
     <p class="card-text">
       If your device is listed but missing a firmware update that you see on the


### PR DESCRIPTION
I have updated an old link that is not correct anymore because the structure of the website has changed.

* Old link: https://fwupd.org/vendorlist
* New link: https://fwupd.org/lvfs/vendors/