### PR TITLE
Replace old, static link in devicelist.html with dynamic link (fixed)

### DIFF
--- a/lvfs/devices/templates/devicelist.html
+++ b/lvfs/devices/templates/devicelist.html
@@ -44,7 +44,7 @@
       This list is automatically generated and will be updated when new firmware
       is added or existing firmware is made available.
       For information about what vendors have been contacted about the LVFS,
-      please see the <a href="/vendorlist">vendor engagement list</a>.
+      please see the <a href="{{url_for('main.route_devicelist')}}">vendor engagement list</a>.
     </p>
     <p class="card-text">
       If your device is listed but missing a firmware update that you see on the

--- a/lvfs/devices/templates/devicelist.html
+++ b/lvfs/devices/templates/devicelist.html
@@ -44,7 +44,7 @@
       This list is automatically generated and will be updated when new firmware
       is added or existing firmware is made available.
       For information about what vendors have been contacted about the LVFS,
-      please see the <a href="{{url_for('main.route_devicelist')}}">vendor engagement list</a>.
+      please see the <a href="{{url_for('main.route_vendorlist')}}">vendor engagement list</a>.
     </p>
     <p class="card-text">
       If your device is listed but missing a firmware update that you see on the


### PR DESCRIPTION
Related to https://github.com/fwupd/lvfs-website/pull/689 .

I have updated an old link that is not correct anymore because the structure of the website has changed. As per the discussion in https://github.com/fwupd/lvfs-website/pull/689 I have now used a dynamic link instead of a hardcoded link.