### PR TITLE
Vendorlist: change "recently" to "last 6 months"

### DIFF
--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -475,7 +475,7 @@ class Vendor(db.Model):
     @property
     @functools.lru_cache()
     def fws_stable_recent(self):
-        now = datetime.datetime.utcnow() - datetime.timedelta(weeks=25)
+        now = datetime.datetime.utcnow() - datetime.timedelta(weeks=26) # 26 weeks is half a year or about 6 months
         return _execute_count_star(db.session.query(Firmware.firmware_id).\
                     join(Firmware.remote).\
                     filter(Remote.name == 'stable',

--- a/lvfs/vendors/templates/vendorlist.html
+++ b/lvfs/vendors/templates/vendorlist.html
@@ -36,7 +36,7 @@
       <span class="fas fa-check-circle fs-2 text-success"></span>
       Responsible for {{v.fws_stable}} firmware files,
 {% if v.fws_stable_recent %}
-      {{v.fws_stable_recent}} uploaded recently
+      {{v.fws_stable_recent}} uploaded in the last 6 months
 {% else %}
       none uploaded recently
 {% endif %}


### PR DESCRIPTION
Related to https://github.com/fwupd/lvfs-website/issues/721

The wording "uploaded recently" should be changed to "uploaded in the last 6 months" to make it more comprehensible.