### PR TITLE
Add card-text for latest devices supported

### DIFF
--- a/lvfs/devices/templates/devicelist.html
+++ b/lvfs/devices/templates/devicelist.html
@@ -22,6 +22,10 @@
 <div class="card mt-3">
   <div class="card-body">
     <h2 class="card-title">Latest Devices Supported</h2>
+    <p class="card-text">
+      This list shows the 6 latest devices supported by the LVFS.
+      This list is automatically generated and will be updated when new devices are supported.
+    </p>
     <ul class="list-group">
 {% for fw in devices %}
       <li class="list-group-item">

--- a/lvfs/devices/templates/devicelist.html
+++ b/lvfs/devices/templates/devicelist.html
@@ -24,7 +24,6 @@
     <h2 class="card-title">Latest Devices Supported</h2>
     <p class="card-text">
       This list shows the 6 latest devices supported by the LVFS.
-      This list is automatically generated and will be updated when new devices are supported.
     </p>
     <ul class="list-group">
 {% for fw in devices %}


### PR DESCRIPTION
While the section "Devices supported by the LVFS" on https://fwupd.org/lvfs/devices/ has a card-text, the section "Latest Devices Supported" does not. To increase consistency I would like to add a card-text for this section as well.