### PR TITLE
Represent concatenation in heading: hardware --> vendor and device name

### DIFF
--- a/lvfs/firmware/templates/firmware-new.html
+++ b/lvfs/firmware/templates/firmware-new.html
@@ -17,7 +17,7 @@
 <table class="table card-text">
   <tr class="row">
     <th class="col col-sm-2">When</th>
-    <th class="col col-sm-5">Hardware</th>
+    <th class="col col-sm-5">Vendor and Device name</th>
     <th class="col col-sm-3">Version</th>
     <th class="col col-sm-2">&nbsp;</th>
   </tr>


### PR DESCRIPTION
The content of this column is the vendor name (developer_name_display) and the device name (name_with_category). These two names get concatenated. To make readers aware of this concatenation, the heading should say that it is actually two pieces of information and not just a single "hardware".