### PR TITLE
Do not configure celery during init

### DIFF
--- a/lvfs/metadata/routes.py
+++ b/lvfs/metadata/routes.py
@@ -19,9 +19,6 @@ from .utils import _async_regenerate_remote_all, _async_regenerate_remote
 
 bp_metadata = Blueprint('metadata', __name__, template_folder='templates')
 
-celery.control.time_limit('lvfs.metadata.utils._async_regenerate_remote',
-                          soft=60, hard=120, reply=True)
-
 @celery.on_after_finalize.connect
 def setup_periodic_tasks(sender, **_):
     sender.add_periodic_task(14400.0, _async_regenerate_remote_all.s(), options={'queue': 'metadata'})


### PR DESCRIPTION
This allows us to run local.py without redis running.