### PR TITLE
Force the uploader after autoimporting issues

### DIFF
--- a/lvfs/components/routes.py
+++ b/lvfs/components/routes.py
@@ -595,13 +595,11 @@ def _autoimport_issues(md, prefix, kind):
         # advance string to end of CVE number
         start = idx + len(prefix) + issue_len
 
+        # add something the user has to manually remove
+        description_new += 'REMOVE_ME'
+
     # success
     if issues:
-        for empty in ['()', '( )', '(  )', '(   )', '(    )',
-                      '(,)', '(, , )', '(, , , )', '(, , , , )',
-                      '( & )']:
-            description_new = description_new.replace(empty, '')
-        description_new = description_new.replace(' \n', '\n')
         md.release_description = description_new
         md.issues.extend(issues)
 

--- a/lvfs/components/routes_test.py
+++ b/lvfs/components/routes_test.py
@@ -193,8 +193,9 @@ class LocalTestCase(LvfsTestCase):
         rv = self.app.get('/lvfs/firmware/1/problems')
         assert b'CVEs in update description' not in rv.data, rv.data.decode()
         rv = self.app.get('/lvfs/components/1/update')
-        assert b'- Address security advisories\n' +\
-               b'- Firmware updates to address security advisory' in rv.data, rv.data.decode()
+        assert b'- Address security advisories' in rv.data, rv.data.decode()
+        assert b'REMOVE_ME' in rv.data, rv.data.decode()
+        assert b'- Firmware updates to address security advisory' in rv.data, rv.data.decode()
 
     def test_device_checksums(self):
 

--- a/lvfs/util.py
+++ b/lvfs/util.py
@@ -164,6 +164,8 @@ def _check_both(problems, txt):
         _add_problem(problems, 'Intel-specific security advisory tag in update description')
     if txt.find('INTEL-TA-') != -1:
         _add_problem(problems, 'Intel-specific technical advisory tag in update description')
+    if txt.find('REMOVE_ME') != -1:
+        _add_problem(problems, 'Update description should be checked after auto-importing issues')
 
 def _check_is_fake_li(txt):
     for line in txt.split('\n'):


### PR DESCRIPTION
Autoimporting issues is hugely useful for uploaders, but several have not been
checking the 'fixed up' update descriptions for sanity, leading to bugs like
https://github.com/fwupd/lvfs-website/issues/758 that keep popping up.

There's no way we can possibly try to make the description sane in all cases,
so just force the uploader to remove the REMOVE_ME keywords and they'll
hopefully make the description a bit easier to read at the same time.