### PR TITLE
Add a vendor legal name

### DIFF
--- a/cron.py
+++ b/cron.py
@@ -95,6 +95,8 @@ def _repair_vendor():
                 v.icon = icon
             except FileNotFoundError as _:
                 pass
+        if not v.legal_name:
+            v.legal_name = v.display_name
 
     for r in db.session.query(Remote):
         if not r.access_token:

--- a/docs/source/apply.rst
+++ b/docs/source/apply.rst
@@ -8,6 +8,7 @@ have, or just with questions or for more details.
 Information to Supply
 =====================
 
+* The vendor full legal name
 * The public homepage for this vendor
 * The domain used for email address assigned to this vendor, e.g. ``@realtek.com,@realtek.com.tw``
 * The update protocol are you using, and if it is already supported in fwupd

--- a/lvfs/dbutils.py
+++ b/lvfs/dbutils.py
@@ -216,7 +216,8 @@ def init_db(db):
         db.session.add(remote)
         db.session.commit()
         vendor = Vendor(group_id='admin')
-        vendor.display_name = 'Acme Corp.'
+        vendor.display_name = 'Acme'
+        vendor.legal_name = 'Acme Corp.'
         vendor.description = 'A fake vendor used for testing firmware'
         vendor.remote_id = remote.remote_id
         db.session.add(vendor)

--- a/lvfs/mdsync/routes_test.py
+++ b/lvfs/mdsync/routes_test.py
@@ -116,11 +116,11 @@ class LocalTestCase(LvfsTestCase):
 
         # list all vendors with different world-views
         rv = self.app.get('/lvfs/mdsync/', follow_redirects=True)
-        assert b'Acme Corp' in rv.data, rv.data.decode()
+        assert b'Acme' in rv.data, rv.data.decode()
 
         # all OEMs scanned by Acme Corp.
         rv = self.app.get('/lvfs/mdsync/1', follow_redirects=True)
-        assert b'Acme Corp.' in rv.data, rv.data.decode()
+        assert b'Acme' in rv.data, rv.data.decode()
 
         # all ColorHug firmware known by Acme Corp.
         rv = self.app.get('/lvfs/mdsync/1/1', follow_redirects=True)

--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -415,6 +415,7 @@ class Vendor(db.Model):
     vendor_id = Column(Integer, primary_key=True)
     group_id = Column(String(80), nullable=False, index=True)
     display_name = Column(Text, default=None)
+    legal_name = Column(Text, default=None)
     internal_team = Column(Text, default=None)
     plugins = Column(Text, default=None)
     description = Column(Text, default=None)

--- a/lvfs/vendors/routes.py
+++ b/lvfs/vendors/routes.py
@@ -508,6 +508,7 @@ def route_modify_by_admin(vendor_id):
         flash('Failed to modify vendor: No a vendor with that group ID', 'warning')
         return redirect(url_for('vendors.route_list_admin'), 302)
     for key in ['display_name',
+                'legal_name',
                 'internal_team',
                 'group_id',
                 'plugins',

--- a/lvfs/vendors/templates/vendor-details.html
+++ b/lvfs/vendors/templates/vendor-details.html
@@ -24,6 +24,10 @@
     <input type="text" class="form-control" name="display_name" value="{{v.display_name}}" required>
   </div>
   <div class="form-group">
+    <label for="display_name">Legal Name:</label>
+    <input type="text" class="form-control" name="display_name" value="{{v.legal_name}}" required>
+  </div>
+  <div class="form-group">
     <label for="internal_team">Internal Team:</label>
     <input type="text" class="form-control" name="internal_team" value="{{v.internal_team if v.internal_team}}">
   </div>

--- a/migrations/versions/fbf18115ec00_vendor_legal_name.py
+++ b/migrations/versions/fbf18115ec00_vendor_legal_name.py
@@ -1,0 +1,22 @@
+"""
+
+Revision ID: fbf18115ec00
+Revises: 18e5e636d4a8
+Create Date: 2020-09-11 09:36:41.437270
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'fbf18115ec00'
+down_revision = '18e5e636d4a8'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('vendors', sa.Column('legal_name', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('vendors', 'legal_name')


### PR DESCRIPTION
In some cases the vendor legal name will be very different from the thing from
what the user expects to see, for instance 'ASUSTeK Computer Inc.' -> 'ASUS'.

We can use this extra field to show the legal string for legal agreements and
the display name everywhere else.