### PR TITLE
Do not allow the vendor name in the firmware name

### DIFF
--- a/lvfs/components/routes_test.py
+++ b/lvfs/components/routes_test.py
@@ -66,6 +66,23 @@ class LocalTestCase(LvfsTestCase):
         rv = self.app.get('/lvfs/firmware/1/problems')
         assert b'ColorHug2 is already part' not in rv.data, rv.data.decode()
 
+    def test_vendor_in_name(self):
+
+        # get the default update info from the firmware archive
+        self.login()
+        self.add_namespace()
+        self.upload()
+
+        # edit the name_variant_suffix to something contained in the <name>
+        rv = self.app.post('/lvfs/components/1/modify', data=dict(
+            name='Acme ColorHug2',
+        ), follow_redirects=True)
+        assert b'Component updated' in rv.data, rv.data
+
+        # verify the new problems
+        rv = self.app.get('/lvfs/firmware/1/problems')
+        assert b'The vendor should not be part of the name' in rv.data, rv.data.decode()
+
     def test_requires(self):
 
         # check existing requires were added

--- a/lvfs/models.py
+++ b/lvfs/models.py
@@ -1762,6 +1762,15 @@ class Component(db.Model):
                                           url=url_for('components.route_show',
                                                       component_id=self.component_id)))
 
+        # name contains the vendor
+        if self.name and self.fw.vendor.display_name:
+            if self.name.upper().find(self.fw.vendor.display_name.upper()) != -1:
+                problems.append(Claim(kind='invalid-name',
+                                      icon='warning',
+                                      summary='The vendor should not be part of the name',
+                                      url=url_for('components.route_show',
+                                                  component_id=self.component_id)))
+
         # add all CVE problems
         for issue in self.issues:
             if issue.problem:


### PR DESCRIPTION
If the uploader makes this mistake then we would display 'ASUS ASUS System'
on the LVFS and the various end-user tools.